### PR TITLE
Use OpenAPI 3.0 Bearer scheme for securityScheme values

### DIFF
--- a/terraform/upload_service.yml
+++ b/terraform/upload_service.yml
@@ -65,9 +65,9 @@ components:
       payloadFormatVersion: 2.0
   securitySchemes:
     token_manifest_auth:
-      type: "apiKey"
-      name: "Unused"
-      in: "header"
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
       x-amazon-apigateway-authorizer:
         identitySource: "$request.header.Authorization,$request.querystring.manifest_id"
         authorizerUri: ${authorize_lambda_invoke_uri}
@@ -77,9 +77,9 @@ components:
         enableSimpleResponses: true
         authorizerCredentials: ${gateway_authorizer_role}
     token_dataset_auth:
-      type: "apiKey"
-      name: "Unused"
-      in: "header"
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
       x-amazon-apigateway-authorizer:
         identitySource: "$request.header.Authorization,$request.querystring.dataset_id"
         authorizerUri: ${authorize_lambda_invoke_uri}
@@ -89,9 +89,9 @@ components:
         enableSimpleResponses: true
         authorizerCredentials: ${gateway_authorizer_role}
     token_auth:
-      type: "apiKey"
-      name: "Authorization"
-      in: "header"
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
       x-amazon-apigateway-authorizer:
         identitySource: "$request.header.Authorization"
         authorizerUri: ${authorize_lambda_invoke_uri}


### PR DESCRIPTION
OpenAPI 3.0 introduced [new syntax for specifying Bearer authentication schemes](https://swagger.io/docs/specification/authentication/bearer-authentication/). This PR switches to that new syntax.

The problem with the current syntax is that it leads to incorrect documentation and generated code on https://docs.pennsieve.io/. That page shows the `Authorization` header without the `Bearer` portion of the header value which is not correct. It also generates incorrect code for the `CURL` examples because of the missing `Bearer`.
