### PR TITLE
Fix for OpenAPI documentation

### DIFF
--- a/.github/workflows/readme.yml
+++ b/.github/workflows/readme.yml
@@ -8,12 +8,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Find and Replace
-        uses: jacobtomlinson/gha-find-replace@master
-        with:
-          find: "Unused"
-          replace: "Authorization"
-          include: "terraform/upload_service.yml"
       - uses: readmeio/rdme@7.3.0
         with:
           rdme: openapi "terraform/upload_service.yml" --key=${{ secrets.README_OAS_KEY }} --id=62fee65f0fde2a00ef3ec784

--- a/terraform/upload_service.yml
+++ b/terraform/upload_service.yml
@@ -65,9 +65,11 @@ components:
       payloadFormatVersion: 2.0
   securitySchemes:
     token_manifest_auth:
-      type: "apiKey"
-      name: "Unused"
-      in: "header"
+      type: apiKey
+      scheme: bearer
+      bearerFormat: JWT
+      name: Authorization
+      in: header
       x-amazon-apigateway-authorizer:
         identitySource: "$request.header.Authorization,$request.querystring.manifest_id"
         authorizerUri: ${authorize_lambda_invoke_uri}
@@ -77,9 +79,11 @@ components:
         enableSimpleResponses: true
         authorizerCredentials: ${gateway_authorizer_role}
     token_dataset_auth:
-      type: "apiKey"
-      name: "Unused"
-      in: "header"
+      type: apiKey
+      scheme: bearer
+      bearerFormat: JWT
+      name: Authorization
+      in: header
       x-amazon-apigateway-authorizer:
         identitySource: "$request.header.Authorization,$request.querystring.dataset_id"
         authorizerUri: ${authorize_lambda_invoke_uri}
@@ -89,9 +93,11 @@ components:
         enableSimpleResponses: true
         authorizerCredentials: ${gateway_authorizer_role}
     token_auth:
-      type: "apiKey"
-      name: "Authorization"
-      in: "header"
+      type: apiKey
+      scheme: bearer
+      bearerFormat: JWT
+      name: Authorization
+      in: header
       x-amazon-apigateway-authorizer:
         identitySource: "$request.header.Authorization"
         authorizerUri: ${authorize_lambda_invoke_uri}


### PR DESCRIPTION
Trying again to get the docs on https://docs.pennsieve.io/ correct, this time without breaking API Gateway.

Follows the example from this [forum post](https://repost.aws/questions/QUSHqmPblDR4W3stiqdIFJHQ/unable-to-import-openapi-3-spec-with-bearer-auth) to keep the security scheme type as `apiKey` but also include Bearer information.