### PR TITLE
Add readme-service to Gateway

### DIFF
--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -166,3 +166,15 @@ data "terraform_remote_state" "rehydration_service" {
     profile = var.aws_account
   }
 }
+
+# Import Readme Service
+data "terraform_remote_state" "readme_service" {
+  backend = "s3"
+
+  config = {
+    bucket  = "${var.aws_account}-terraform-state"
+    key     = "aws/${data.aws_region.current_region.name}/${var.vpc_name}/${var.environment_name}/readme-service/terraform.tfstate"
+    region  = "us-east-1"
+    profile = var.aws_account
+  }
+}

--- a/terraform/gateway.tf
+++ b/terraform/gateway.tf
@@ -17,6 +17,7 @@ resource "aws_apigatewayv2_api" "upload-service-gateway" {
     packages_service_lambda_arn = data.terraform_remote_state.packages_service.outputs.service_lambda_arn,
     integration_service_lambda_arn = data.terraform_remote_state.integration_service.outputs.lambda_service_arn,
     rehydration_service_lambda_arn = data.terraform_remote_state.rehydration_service.outputs.rehydration_service_arn,
+    readme_service_lambda_arn = data.terraform_remote_state.readme_service.outputs.service_lambda_arn,
     user_pool_2_client_id = data.terraform_remote_state.authentication_service.outputs.user_pool_2_client_id,
     user_pool_endpoint = "https://${var.user_pool_endpoint}"
     token_pool_client_id = data.terraform_remote_state.authentication_service.outputs.token_pool_client_id,

--- a/terraform/upload_service.yml
+++ b/terraform/upload_service.yml
@@ -1607,8 +1607,7 @@ paths:
           required: true
           schema:
             type: string
-            minimum: 1
-          description: The slug of the readme.io doc. Slugs must be all lowercase, and replace spaces with hyphens.
+          description: The URL-safe slug of the readme.io doc. Slugs must be all lowercase, and replace spaces with hyphens.
       responses:
         '200':
           description: The requested document

--- a/terraform/upload_service.yml
+++ b/terraform/upload_service.yml
@@ -76,7 +76,14 @@ components:
       httpMethod: POST
       passthroughBehavior: when_no_match
       contentHandling: CONVERT_TO_TEXT
-      payloadFormatVersion: 2.0          
+      payloadFormatVersion: 2.0
+    readme-service:
+      type: aws_proxy
+      uri: ${readme_service_lambda_arn}
+      httpMethod: POST
+      passthroughBehavior: when_no_match
+      contentHandling: CONVERT_TO_TEXT
+      payloadFormatVersion: 2.0
   securitySchemes:
     token_manifest_auth:
       type: "apiKey"
@@ -1580,4 +1587,36 @@ paths:
         '4XX':
           $ref: '#/components/responses/Unauthorized'
         '5XX':
-          $ref: '#/components/responses/Error'          
+          $ref: '#/components/responses/Error'
+
+  /readme/docs/{slug}:
+    get:
+      summary: Get Pennsieve readme.io doc by slug
+      description: |
+        Gets Pennsieve readme.io doc by slug
+      x-amazon-apigateway-integration:
+        $ref: '#/components/x-amazon-apigateway-integrations/readme-service'
+      operationId: getReadmeDoc
+      security:
+        - token_auth: [ ]
+      tags:
+        - Readme Service
+      parameters:
+        - in: path
+          name: slug
+          required: true
+          schema:
+            type: string
+            minimum: 1
+          description: The slug of the readme.io doc. Slugs must be all lowercase, and replace spaces with hyphens.
+      responses:
+        '200':
+          description: The requested document
+          content:
+            application/json:
+              schema:
+                $ref: 'https://dash.readme.com/api/v1/schema#/components/schemas/docSchemaResponse'
+        '4XX':
+          $ref: '#/components/responses/Unauthorized'
+        '5XX':
+          $ref: '#/components/responses/Error'


### PR DESCRIPTION
Adds a new service, readme-service to the Gateway API.

The new endpoint, `/readme/docs/{slug}` acts as a proxy for the readme.io API to return Pennsieve documents.
