### PR TITLE
Remove authentication and authorization from /rehydrate endpoint

### DIFF
--- a/terraform/upload_service.yml
+++ b/terraform/upload_service.yml
@@ -1558,7 +1558,7 @@ paths:
         '5XX':
           $ref: '#/components/responses/Error'         
 
-  /rehydrate:
+  /discover/rehydrate:
     post:
       summary: Execute rehydration
       description: |
@@ -1567,7 +1567,7 @@ paths:
         $ref: '#/components/x-amazon-apigateway-integrations/rehydration-service'
       operationId: rehydrate
       tags:
-        - Rehydration Service
+        - Discover/Rehydration Service
       requestBody:
         description: Payload
         required: true

--- a/terraform/upload_service.yml
+++ b/terraform/upload_service.yml
@@ -1566,8 +1566,6 @@ paths:
       x-amazon-apigateway-integration:
         $ref: '#/components/x-amazon-apigateway-integrations/rehydration-service'
       operationId: rehydrate
-      security:
-        - token_auth: [ ]
       tags:
         - Rehydration Service
       requestBody:


### PR DESCRIPTION
The public Discover API mostly does not require authentication or authorization. The `/rehydrate` endpoint is part of this API, so this PR removes the requirement to provide an `Authorization` header when using the endpoint.