### PR TITLE
8688wm1xv add import-service to API Gateway

### DIFF
--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -143,6 +143,18 @@ data "terraform_remote_state" "packages_service" {
   }
 }
 
+# Import Service
+data "terraform_remote_state" "import_service" {
+  backend = "s3"
+
+  config = {
+    bucket  = "${var.aws_account}-terraform-state"
+    key     = "aws/${data.aws_region.current_region.name}/${var.vpc_name}/${var.environment_name}/import-service/terraform.tfstate"
+    region  = "us-east-1"
+    profile = var.aws_account
+  }
+}
+
 # Import Integration Service
 data "terraform_remote_state" "integration_service" {
   backend = "s3"

--- a/terraform/gateway.tf
+++ b/terraform/gateway.tf
@@ -15,6 +15,7 @@ resource "aws_apigatewayv2_api" "upload-service-gateway" {
     publishing_service_lambda_arn = data.terraform_remote_state.publishing_service.outputs.service_lambda_arn,
     datasets_service_lambda_arn = data.terraform_remote_state.datasets_service.outputs.service_lambda_arn,
     packages_service_lambda_arn = data.terraform_remote_state.packages_service.outputs.service_lambda_arn,
+    import_service = data.terraform_remote_state.import_service.outputs.import_service_arn,
     integration_service_lambda_arn = data.terraform_remote_state.integration_service.outputs.lambda_service_arn,
     rehydration_service_lambda_arn = data.terraform_remote_state.rehydration_service.outputs.rehydration_service_arn,
     readme_service_lambda_arn = data.terraform_remote_state.readme_service.outputs.service_lambda_arn,

--- a/terraform/upload_service.yml
+++ b/terraform/upload_service.yml
@@ -344,6 +344,14 @@ components:
           description: the packageIds
           items:
             type: string              
+    createImportManifestRequest:
+      type: object
+    createImportManifestResponse:
+      type: object
+      properties:
+        uuid:
+          type: string
+          description: the uuid of the import manifest
     rehydrationRequest:
       type: object
       properties:
@@ -2169,6 +2177,35 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '5XX':
           $ref: '#/components/responses/Error'      
+
+  /import/manifest:
+    post:
+      summary: Create import manifest
+      description: |
+        Calls endpoint on import-service to create an import manifest
+      x-amazon-apigateway-integration:
+        $ref: '#/components/x-amazon-apigateway-integrations/import-service'
+      operationId: createImportManifest
+      tags:
+        - Import Service
+      requestBody:
+        description: Import Manifest
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/createImportManifestRequest'
+      responses:
+        '200':
+          description: Created import manifest.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/createImportManifestResponse'
+        '4XX':
+          $ref: '#/components/responses/Unauthorized'
+        '5XX':
+          $ref: '#/components/responses/Error'
 
   /discover/rehydrate:
     post:


### PR DESCRIPTION
## Description

**Clickup Ticket:** [8688wm1xv](https://app.clickup.com/t/8688wm1xv)

Adds import-service Lambda to AWS API Gateway to service import manifest creation and management.

Added the `POST /import/manifest` endpoint with limited details for now just for testing purposes.

## Terraform Plan
```
...
          +   /import/manifest:
          +     post:
          +       summary: Create import manifest
          +       description: |
          +         Calls endpoint on import-service to create an import manifest
          +       x-amazon-apigateway-integration:
          +         $ref: '#/components/x-amazon-apigateway-integrations/import-service'
          +       operationId: createImportManifest
          +       tags:
          +         - Import Service
          +       requestBody:
          +         description: Import Manifest
          +         required: true
          +         content:
          +           application/json:
          +             schema:
          +               $ref: '#/components/schemas/createImportManifestRequest'
          +       responses:
          +         '200':
          +           description: Created import manifest.
          +           content:
          +             application/json:
          +               schema:
          +                 $ref: '#/components/schemas/createImportManifestResponse'
          +         '4XX':
          +           $ref: '#/components/responses/Unauthorized'
          +         '5XX':
          +           $ref: '#/components/responses/Error'
          +

...
      ~ description                  = <<-EOT
          - Version 2 of the Pennsieve API.\
          - \
          - This is the second iteration of the Pennsieve API and will, over time, replace functionality that is currently included in the first version of the API.
          + API Gateway for Upload-Service V2
        EOT
        id                           = "14i0ufp7jh"
      ~ name                         = "Pennsieve API Version 2" -> "serverless_upload_service"
      ~ tags                         = {
          - "Upload Service" = "" -> null
        }
      ~ tags_all                     = {
          - "Upload Service" = "" -> null
        }
      - version                      = "1.0.0" -> null
        # (7 unchanged attributes hidden)

        # (1 unchanged block hidden)
    }

  # module.uploads_module.aws_lambda_function.authorizer_lambda will be updated in-place
  ~ resource "aws_lambda_function" "authorizer_lambda" {
        id                             = "dev-pennsieve-go-api-authorizer_lambda-use1"
      ~ last_modified                  = "2024-08-13T21:20:29.000+0000" -> (known after apply)
      ~ s3_key                         = "pennsieve-go-api/api-v2-authorizer-85-45e4139.zip" -> "pennsieve-go-api/api-v2-authorizer-.zip"
        tags                           = {}
        # (23 unchanged attributes hidden)





        # (5 unchanged blocks hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

```