### PR TITLE
Two new Endpoints to support Code Repos

### DIFF
--- a/terraform/upload_service.yml
+++ b/terraform/upload_service.yml
@@ -962,6 +962,16 @@ components:
             contributors:
               type: boolean
 
+    publishRepositoryRequest:
+      type: object
+      properties:
+        id:
+          type: integer
+        url:
+          type: string
+        type:
+          type: string
+
     githubRepo:
       type: object
       properties:
@@ -3363,7 +3373,38 @@ paths:
               $ref: '#/components/schemas/updateRepositoryRequest'
       responses:
         '200':
-          description: Successfully disabled tracking of the external repository.
+          description: Successfully updated the external repository.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/externalRepository'
+        '4XX':
+          $ref: '#/components/responses/Unauthorized'
+        '5XX':
+          $ref: '#/components/responses/Error'
+
+  /repository/publish:
+    post:
+      summary: request publishing of an external repository
+      description: |
+        Requests that an external repository be published.
+      x-amazon-apigateway-integration:
+        $ref: '#/components/x-amazon-apigateway-integrations/github-service'
+      security:
+        - token_auth: [ ]
+      operationId: publishRepository
+      tags:
+        - Repository Service
+      requestBody:
+        description: Payload
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/publishRepositoryRequest'
+      responses:
+        '201':
+          description: Successfully published the external repository.
           content:
             application/json:
               schema:

--- a/terraform/upload_service.yml
+++ b/terraform/upload_service.yml
@@ -932,6 +932,36 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/externalRepository"
+
+    updateRepositoryRequest:
+      type: object
+      properties:
+        id:
+          type: integer
+        url:
+          type: string
+        name:
+          type: string
+        subtitle:
+          type: string
+        auto_publish:
+          type: boolean
+        tags:
+          type: array
+        sync:
+          type: object
+          properties:
+            banner:
+              type: boolean
+            readme:
+              type: boolean
+            changelog:
+              type: boolean
+            license:
+              type: boolean
+            contributors:
+              type: boolean
+
     githubRepo:
       type: object
       properties:
@@ -3302,6 +3332,37 @@ paths:
               $ref: '#/components/schemas/trackRepositoryRequest'
       responses:
         '201':
+          description: Successfully disabled tracking of the external repository.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/externalRepository'
+        '4XX':
+          $ref: '#/components/responses/Unauthorized'
+        '5XX':
+          $ref: '#/components/responses/Error'
+
+  /repository/external:
+    put:
+      summary: Update the attributes of an external repository
+      description: |
+        Updates the External Repository and the attached Dataset
+      x-amazon-apigateway-integration:
+        $ref: '#/components/x-amazon-apigateway-integrations/github-service'
+      operationId: updateExternalRepo
+      security:
+        - token_auth: [ ]
+      tags:
+        - Repository Service
+      requestBody:
+        description: Payload
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/updateRepositoryRequest'
+      responses:
+        '200':
           description: Successfully disabled tracking of the external repository.
           content:
             application/json:


### PR DESCRIPTION
Added the following endpoints:
- **PUT** `/repository/external` for updating en External Repository
- **POST** `/repository/publis` to request publishing of an External Repository