### PR TITLE
fix: refactors to remove static identity source

### DIFF
--- a/lambda/authorizer/factory/factory.go
+++ b/lambda/authorizer/factory/factory.go
@@ -4,10 +4,12 @@ import (
 	"errors"
 
 	"github.com/pennsieve/pennsieve-go-api/authorizer/authorizers"
+	"github.com/pennsieve/pennsieve-go-api/authorizer/helpers"
+	log "github.com/sirupsen/logrus"
 )
 
 type AuthorizerFactory interface {
-	Build([]string) (authorizers.Authorizer, error)
+	Build([]string, map[string]string) (authorizers.Authorizer, error)
 }
 
 type CustomAuthorizerFactory struct{}
@@ -16,17 +18,30 @@ func NewCustomAuthorizerFactory() AuthorizerFactory {
 	return &CustomAuthorizerFactory{}
 }
 
-func (f *CustomAuthorizerFactory) Build(identitySource []string) (authorizers.Authorizer, error) {
-	switch identitySource[0] {
-	case "DatasetAuthorizer":
-		return authorizers.NewDatasetAuthorizer(identitySource[2]), nil
-	case "ManifestAuthorizer":
-		return authorizers.NewManifestAuthorizer(identitySource[2]), nil // will be deprecated
-	case "WorkspaceAuthorizer":
-		return authorizers.NewWorkspaceAuthorizer(identitySource[2]), nil
-	case "UserAuthorizer":
+func (f *CustomAuthorizerFactory) Build(identitySource []string, queryStringParameters map[string]string) (authorizers.Authorizer, error) {
+	if !helpers.Matches(identitySource[0], `Bearer (?P<token>.*)`) {
+		errorString := "token expected to be first identity source"
+		log.Error(errorString)
+		return nil, errors.New(errorString)
+	}
+
+	var hasManifestId bool
+	manifest_id, hasManifestId := queryStringParameters["manifest_id"]
+	if manifest_id == "" {
+		hasManifestId = false
+	}
+
+	switch {
+	case len(identitySource) == 1:
 		return authorizers.NewUserAuthorizer(), nil
+	case len(identitySource) > 1 && helpers.Matches(identitySource[1], `N:dataset:`):
+		return authorizers.NewDatasetAuthorizer(identitySource[1]), nil
+	case len(identitySource) > 1 && helpers.Matches(identitySource[1], `N:organization:`):
+		return authorizers.NewWorkspaceAuthorizer(identitySource[1]), nil
+	case len(identitySource) > 1 && hasManifestId:
+		return authorizers.NewManifestAuthorizer(identitySource[1]), nil // will be deprecated
 	default:
-		return nil, errors.New("unsupported authorizer")
+		return nil, errors.New("no suitable authorizer to process request")
+
 	}
 }

--- a/lambda/authorizer/factory/factory_test.go
+++ b/lambda/authorizer/factory/factory_test.go
@@ -32,4 +32,9 @@ func TestFactory(t *testing.T) {
 	authorizer, _ = authFactory.Build(WorkspaceIdentitySource, withWorkspaceId)
 	assert.Equal(t, fmt.Sprintf("%T", authorizer), "*authorizers.WorkspaceAuthorizer")
 
+	WorkspaceIdentitySource2 := []string{"N:organization:some-uuid"}
+	authorizer, err := authFactory.Build(WorkspaceIdentitySource2, withWorkspaceId)
+	assert.Equal(t, authorizer, nil)
+	assert.Equal(t, err.Error(), "token expected to be first identity source")
+
 }

--- a/lambda/authorizer/factory/factory_test.go
+++ b/lambda/authorizer/factory/factory_test.go
@@ -11,20 +11,25 @@ import (
 func TestFactory(t *testing.T) {
 	authFactory := factory.NewCustomAuthorizerFactory()
 
-	UserIdentitySource := []string{"UserAuthorizer", "Bearer eyJra.some.random.string"}
-	authorizer, _ := authFactory.Build(UserIdentitySource)
+	withManifestId := map[string]string{"manifest_id": "someManifestId"}
+	withDatasetId := map[string]string{"dataset_id": "someDatasetId"}
+	withWorkspaceId := map[string]string{"dataset_id": "somehWorkspaceId"}
+	withoutQueryParams := map[string]string{}
+
+	UserIdentitySource := []string{"Bearer eyJra.some.random.string"}
+	authorizer, _ := authFactory.Build(UserIdentitySource, withoutQueryParams)
 	assert.Equal(t, fmt.Sprintf("%T", authorizer), "*authorizers.UserAuthorizer")
 
-	DatasetIdentitySource := []string{"DatasetAuthorizer", "Bearer eyJra.some.random.string", "N:dataset:some-uuid"}
-	authorizer, _ = authFactory.Build(DatasetIdentitySource)
+	DatasetIdentitySource := []string{"Bearer eyJra.some.random.string", "N:dataset:some-uuid"}
+	authorizer, _ = authFactory.Build(DatasetIdentitySource, withDatasetId)
 	assert.Equal(t, fmt.Sprintf("%T", authorizer), "*authorizers.DatasetAuthorizer")
 
-	ManifestIdentitySource := []string{"ManifestAuthorizer", "Bearer eyJra.some.random.string", "someManifestId"}
-	authorizer, _ = authFactory.Build(ManifestIdentitySource)
+	ManifestIdentitySource := []string{"Bearer eyJra.some.random.string", "someManifestId"}
+	authorizer, _ = authFactory.Build(ManifestIdentitySource, withManifestId)
 	assert.Equal(t, fmt.Sprintf("%T", authorizer), "*authorizers.ManifestAuthorizer")
 
-	WorkspaceIdentitySource := []string{"WorkspaceAuthorizer", "Bearer eyJra.some.random.string", "N:organization:some-uuid"}
-	authorizer, _ = authFactory.Build(WorkspaceIdentitySource)
+	WorkspaceIdentitySource := []string{"Bearer eyJra.some.random.string", "N:organization:some-uuid"}
+	authorizer, _ = authFactory.Build(WorkspaceIdentitySource, withWorkspaceId)
 	assert.Equal(t, fmt.Sprintf("%T", authorizer), "*authorizers.WorkspaceAuthorizer")
 
 }

--- a/lambda/authorizer/handler/handler.go
+++ b/lambda/authorizer/handler/handler.go
@@ -106,7 +106,7 @@ func Handler(ctx context.Context, event events.APIGatewayV2CustomAuthorizerV2Req
 	dynamoDB := dydb.New(client)
 
 	// Get claims
-	identityService := service.NewIdentitySourceService(event.IdentitySource)
+	identityService := service.NewIdentitySourceService(event.IdentitySource, event.QueryStringParameters)
 	authorizer, err := identityService.GetAuthorizer(ctx)
 	if err != nil {
 		return events.APIGatewayV2CustomAuthorizerSimpleResponse{

--- a/lambda/authorizer/helpers/helpers.go
+++ b/lambda/authorizer/helpers/helpers.go
@@ -1,0 +1,11 @@
+package helpers
+
+import (
+	"regexp"
+)
+
+func Matches(stringToMatch string, expression string) bool {
+	r := regexp.MustCompile(expression)
+	parts := r.FindStringSubmatch(stringToMatch)
+	return parts != nil
+}

--- a/lambda/authorizer/helpers/helpers_test.go
+++ b/lambda/authorizer/helpers/helpers_test.go
@@ -1,0 +1,18 @@
+package helpers_test
+
+import (
+	"testing"
+
+	"github.com/pennsieve/pennsieve-go-api/authorizer/helpers"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHelpers(t *testing.T) {
+	UserIdentitySource := []string{"Bearer eyJra.some.random.string"}
+	result := helpers.Matches(UserIdentitySource[0], `Bearer (?P<token>.*)`)
+	assert.Equal(t, result, true)
+
+	UserIdentitySource2 := []string{"earer eyJra.some.random.string"}
+	result = helpers.Matches(UserIdentitySource2[0], `Bearer (?P<token>.*)`)
+	assert.Equal(t, result, false)
+}

--- a/lambda/authorizer/service/identity_source_service.go
+++ b/lambda/authorizer/service/identity_source_service.go
@@ -12,13 +12,14 @@ type IdentityService interface {
 }
 
 type IdentitySourceService struct {
-	IdentitySource []string
+	IdentitySource        []string
+	QueryStringParameters map[string]string
 }
 
-func NewIdentitySourceService(IdentitySource []string) IdentityService {
-	return &IdentitySourceService{IdentitySource}
+func NewIdentitySourceService(IdentitySource []string, queryStringParameters map[string]string) IdentityService {
+	return &IdentitySourceService{IdentitySource, queryStringParameters}
 }
 
 func (i *IdentitySourceService) GetAuthorizer(ctx context.Context) (authorizers.Authorizer, error) {
-	return factory.NewCustomAuthorizerFactory().Build(i.IdentitySource)
+	return factory.NewCustomAuthorizerFactory().Build(i.IdentitySource, i.QueryStringParameters)
 }

--- a/terraform/upload_service.yml
+++ b/terraform/upload_service.yml
@@ -146,7 +146,7 @@ components:
       name: "Unused"
       in: "header"
       x-amazon-apigateway-authorizer:
-        identitySource: "'ManifestAuthorizer',$request.header.Authorization,$request.querystring.manifest_id"
+        identitySource: "$request.header.Authorization,$request.querystring.manifest_id"
         authorizerUri: ${authorize_lambda_invoke_uri}
         authorizerPayloadFormatVersion: "2.0"
         authorizerResultTtlInSeconds: 300
@@ -158,7 +158,7 @@ components:
       name: "Unused"
       in: "header"
       x-amazon-apigateway-authorizer:
-        identitySource: "'DatasetAuthorizer',$request.header.Authorization,$request.querystring.dataset_id"
+        identitySource: "$request.header.Authorization,$request.querystring.dataset_id"
         authorizerUri: ${authorize_lambda_invoke_uri}
         authorizerPayloadFormatVersion: "2.0"
         authorizerResultTtlInSeconds: 300
@@ -170,7 +170,7 @@ components:
       name: "Authorization"
       in: "header"
       x-amazon-apigateway-authorizer:
-        identitySource: "'UserAuthorizer',$request.header.Authorization"
+        identitySource: "$request.header.Authorization"
         authorizerUri: ${authorize_lambda_invoke_uri}
         authorizerPayloadFormatVersion: "2.0"
         authorizerResultTtlInSeconds: 300
@@ -182,7 +182,7 @@ components:
       name: "Unused"
       in: "header"
       x-amazon-apigateway-authorizer:
-        identitySource: "'WorkspaceAuthorizer',$request.header.Authorization,$request.querystring.organization_id"
+        identitySource: "$request.header.Authorization,$request.querystring.organization_id"
         authorizerUri: ${authorize_lambda_invoke_uri}
         authorizerPayloadFormatVersion: "2.0"
         authorizerResultTtlInSeconds: 300


### PR DESCRIPTION
- refactor authorizer to use a combination of identity source and query params (particularly for manifest_id)