### PR TITLE
fix: sends logs to datadog

### DIFF
--- a/terraform/cloudwatch.tf
+++ b/terraform/cloudwatch.tf
@@ -5,11 +5,11 @@
 #   tags = local.common_tags
 # }
 
-// Send logs from upload trigger lambda to datadog
-# resource "aws_cloudwatch_log_subscription_filter" "cloudwatch_log_group_subscription" {
-#   name            = "/aws/lambda/${aws_lambda_function.authorizer_lambda.function_name}-subscription"
-#   log_group_name  = "/aws/lambda/${aws_lambda_function.authorizer_lambda.function_name}"
-#   filter_pattern  = ""
-#   destination_arn = data.terraform_remote_state.region.outputs.datadog_delivery_stream_arn
-#   role_arn        = data.terraform_remote_state.region.outputs.cw_logs_to_datadog_logs_firehose_role_arn
-#}
+// Send logs from authorizer lambda to datadog
+resource "aws_cloudwatch_log_subscription_filter" "cloudwatch_log_group_subscription" {
+  name            = "/aws/lambda/${aws_lambda_function.authorizer_lambda.function_name}-subscription"
+  log_group_name  = "/aws/lambda/${aws_lambda_function.authorizer_lambda.function_name}"
+  filter_pattern  = ""
+  destination_arn = data.terraform_remote_state.region.outputs.datadog_delivery_stream_arn
+  role_arn        = data.terraform_remote_state.region.outputs.cw_logs_to_datadog_logs_firehose_role_arn
+}


### PR DESCRIPTION
- sends logs to datadog

Background:
- I think this was originally commented out as it broke the build, as the log group already existed (perhaps historically added manually). This change uses the already existent log group to enable sending logs to datadog.