### PR TITLE
Create a structured logger in authorizer handler 

### DIFF
--- a/lambda/authorizer/authorizers/dataset_authorizer.go
+++ b/lambda/authorizer/authorizers/dataset_authorizer.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/pennsieve/pennsieve-go-api/authorizer/manager"
 	"github.com/pennsieve/pennsieve-go-core/pkg/models/dataset/role"
-	log "github.com/sirupsen/logrus"
 )
 
 type DatasetAuthorizer struct {
@@ -22,8 +21,7 @@ func (d *DatasetAuthorizer) GenerateClaims(ctx context.Context, claimsManager ma
 	// Get current user
 	currentUser, err := claimsManager.GetCurrentUser(ctx)
 	if err != nil {
-		log.Error("unable to get current user")
-		return nil, err
+		return nil, fmt.Errorf("unable to get current user: %w", err)
 	}
 
 	// Get Active Org
@@ -32,19 +30,16 @@ func (d *DatasetAuthorizer) GenerateClaims(ctx context.Context, claimsManager ma
 	// Get Workspace Claim
 	orgClaim, err := claimsManager.GetOrgClaim(ctx, currentUser, orgInt)
 	if err != nil {
-		log.Error("unable to get Organization Role")
-		return nil, err
+		return nil, fmt.Errorf("unable to get Organization Role: %w", err)
 	}
 
 	// Get Dataset Claim
 	datasetClaim, err := claimsManager.GetDatasetClaim(ctx, currentUser, d.DatasetId, orgInt)
 	if err != nil {
-		log.Error("unable to get Dataset Role")
-		return nil, err
+		return nil, fmt.Errorf("unable to get Dataset Role: %w", err)
 	}
 	// If user has no role on provided dataset --> return
 	if datasetClaim.Role == role.None {
-		log.Error("user has no access to dataset")
 		return nil, errors.New("user has no access to dataset")
 	}
 
@@ -55,9 +50,8 @@ func (d *DatasetAuthorizer) GenerateClaims(ctx context.Context, claimsManager ma
 		// Get Publisher's Claim
 		teamClaims, err := claimsManager.GetTeamClaims(ctx, currentUser)
 		if err != nil {
-			log.Error(fmt.Sprintf("unable to get Team Claims for user: %d organization: %d",
-				currentUser.Id, orgInt))
-			return nil, err
+			return nil, fmt.Errorf("unable to get Team Claims for user: %d organization: %d: %w",
+				currentUser.Id, orgInt, err)
 		}
 
 		return map[string]interface{}{

--- a/lambda/authorizer/authorizers/manifest_authorizer.go
+++ b/lambda/authorizer/authorizers/manifest_authorizer.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/pennsieve/pennsieve-go-api/authorizer/manager"
 	"github.com/pennsieve/pennsieve-go-core/pkg/models/dataset/role"
-	log "github.com/sirupsen/logrus"
 )
 
 // will be deprecated
@@ -23,8 +22,7 @@ func (m *ManifestAuthorizer) GenerateClaims(ctx context.Context, claimsManager m
 	// Get current user
 	currentUser, err := claimsManager.GetCurrentUser(ctx)
 	if err != nil {
-		log.Error("unable to get current user")
-		return nil, err
+		return nil, fmt.Errorf("unable to get current user: %w", err)
 	}
 
 	// Get Active Org
@@ -33,25 +31,21 @@ func (m *ManifestAuthorizer) GenerateClaims(ctx context.Context, claimsManager m
 	// Get Workspace Claim
 	orgClaim, err := claimsManager.GetOrgClaim(ctx, currentUser, orgInt)
 	if err != nil {
-		log.Error("unable to get Organization Role")
-		return nil, err
+		return nil, fmt.Errorf("unable to get Organization Role: %w", err)
 	}
 
 	// Get datasetID
 	datasetID, err := claimsManager.GetDatasetID(ctx, m.ManifestID)
 	if err != nil {
-		log.Error("datasetId could not be retrieved")
-		return nil, err
+		return nil, fmt.Errorf("datasetId could not be retrieved: %w", err)
 	}
 	// Get Dataset Claim
 	datasetClaim, err := claimsManager.GetDatasetClaim(ctx, currentUser, *datasetID, orgInt)
 	if err != nil {
-		log.Error("unable to get Dataset Role")
-		return nil, err
+		return nil, fmt.Errorf("unable to get Dataset Role: %w", err)
 	}
 	// If user has no role on provided dataset --> return
 	if datasetClaim.Role == role.None {
-		log.Error("user has no access to dataset")
 		return nil, errors.New("user has no access to dataset")
 	}
 
@@ -62,9 +56,8 @@ func (m *ManifestAuthorizer) GenerateClaims(ctx context.Context, claimsManager m
 		// Get Publisher's Claim
 		teamClaims, err := claimsManager.GetTeamClaims(ctx, currentUser)
 		if err != nil {
-			log.Error(fmt.Sprintf("unable to get Team Claims for user: %d organization: %d",
-				currentUser.Id, orgInt))
-			return nil, err
+			return nil, fmt.Errorf("unable to get Team Claims for user: %d organization: %d: %w",
+				currentUser.Id, orgInt, err)
 		}
 
 		return map[string]interface{}{

--- a/lambda/authorizer/authorizers/user_authorizer.go
+++ b/lambda/authorizer/authorizers/user_authorizer.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/pennsieve/pennsieve-go-api/authorizer/manager"
-	log "github.com/sirupsen/logrus"
 )
 
 type UserAuthorizer struct{}
@@ -18,8 +17,7 @@ func (u *UserAuthorizer) GenerateClaims(ctx context.Context, claimsManager manag
 	// Get current user
 	currentUser, err := claimsManager.GetCurrentUser(ctx)
 	if err != nil {
-		log.Error("unable to get current user")
-		return nil, err
+		return nil, fmt.Errorf("unable to get current user: %w", err)
 	}
 	// Get User Claim
 	userClaim := claimsManager.GetUserClaim(ctx, currentUser)
@@ -31,16 +29,15 @@ func (u *UserAuthorizer) GenerateClaims(ctx context.Context, claimsManager manag
 		// Get Workspace Claim
 		orgClaim, err := claimsManager.GetOrgClaim(ctx, currentUser, orgInt)
 		if err != nil {
-			log.Error("unable to get Organization Role")
-			return nil, err
+			return nil, fmt.Errorf("unable to get Organization Role: %w", err)
+
 		}
 
 		// Get Publisher's Claim
 		teamClaims, err := claimsManager.GetTeamClaims(ctx, currentUser)
 		if err != nil {
-			log.Error(fmt.Sprintf("unable to get Team Claims for user: %d organization: %d",
-				currentUser.Id, orgInt))
-			return nil, err
+			return nil, fmt.Errorf("unable to get Team Claims for user: %d organization: %d: %w",
+				currentUser.Id, orgInt, err)
 		}
 
 		return map[string]interface{}{

--- a/lambda/authorizer/authorizers/workspace_authorizer.go
+++ b/lambda/authorizer/authorizers/workspace_authorizer.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/pennsieve/pennsieve-go-api/authorizer/manager"
-	log "github.com/sirupsen/logrus"
 )
 
 type WorkspaceAuthorizer struct {
@@ -20,8 +19,7 @@ func (w *WorkspaceAuthorizer) GenerateClaims(ctx context.Context, claimsManager 
 	// Get current user
 	currentUser, err := claimsManager.GetCurrentUser(ctx)
 	if err != nil {
-		log.Error("unable to get current user")
-		return nil, err
+		return nil, fmt.Errorf("unable to get current user: %w", err)
 	}
 
 	// Get Active Org
@@ -30,16 +28,14 @@ func (w *WorkspaceAuthorizer) GenerateClaims(ctx context.Context, claimsManager 
 	// Get Workspace Claim
 	orgClaim, err := claimsManager.GetOrgClaim(ctx, currentUser, orgInt)
 	if err != nil {
-		log.Error("unable to get Organization Role")
-		return nil, err
+		return nil, fmt.Errorf("unable to get Organization Role: %w", err)
 	}
 
 	// Get Publisher's Claim
 	teamClaims, err := claimsManager.GetTeamClaims(ctx, currentUser)
 	if err != nil {
-		log.Error(fmt.Sprintf("unable to get Team Claims for user: %d organization: %d",
-			currentUser.Id, orgInt))
-		return nil, err
+		return nil, fmt.Errorf("unable to get Team Claims for user: %d organization: %d: %w",
+			currentUser.Id, orgInt, err)
 	}
 
 	// Get User Claim

--- a/lambda/authorizer/factory/factory.go
+++ b/lambda/authorizer/factory/factory.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/pennsieve/pennsieve-go-api/authorizer/authorizers"
 	"github.com/pennsieve/pennsieve-go-api/authorizer/helpers"
-	log "github.com/sirupsen/logrus"
 )
 
 type AuthorizerFactory interface {
@@ -22,7 +21,6 @@ func NewCustomAuthorizerFactory() AuthorizerFactory {
 func (f *CustomAuthorizerFactory) Build(identitySource []string, queryStringParameters map[string]string) (authorizers.Authorizer, error) {
 	if !helpers.Matches(identitySource[0], `Bearer (?P<token>.*)`) {
 		errorString := "token expected to be first identity source"
-		log.Error(errorString)
 		return nil, errors.New(errorString)
 	}
 
@@ -40,7 +38,6 @@ func (f *CustomAuthorizerFactory) Build(identitySource []string, queryStringPara
 
 	paramIdentitySource, err := helpers.DecodeIdentitySource(identitySource[1])
 	if err != nil {
-		log.Error(err)
 		return nil, fmt.Errorf("could not decode identity source: %w", err)
 	}
 


### PR DESCRIPTION
PR creates a structured logger in the authorizer handler to improve log searches.

Also centralizes all error logging to the handler function, so that other functions only return detailed errors instead of logging them themselves. Updates these errors to include the initial error so that info is no longer lost.