### PR TITLE
Update to Pennsieve Go Core v1.13.0

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM golang:1.18-alpine
+FROM golang:1.22-alpine
   
   # Install git
 RUN set -ex; \

--- a/lambda/authorizer/authorizers/authorizer.go
+++ b/lambda/authorizer/authorizers/authorizer.go
@@ -6,11 +6,6 @@ import (
 	"github.com/pennsieve/pennsieve-go-api/authorizer/manager"
 )
 
-const LabelUserClaim = "user_claim"
-const LabelOrganizationClaim = "org_claim"
-const LabelTeamClaims = "team_claims"
-const LabelDatasetClaim = "dataset_claim"
-
 type Authorizer interface {
 	GenerateClaims(context.Context, manager.IdentityManager, string) (map[string]interface{}, error)
 }

--- a/lambda/authorizer/authorizers/dataset_authorizer.go
+++ b/lambda/authorizer/authorizers/dataset_authorizer.go
@@ -6,7 +6,8 @@ import (
 	"fmt"
 
 	"github.com/pennsieve/pennsieve-go-api/authorizer/manager"
-	"github.com/pennsieve/pennsieve-go-core/pkg/models/dataset/role"
+	coreAuthorizer "github.com/pennsieve/pennsieve-go-core/pkg/authorizer"
+	"github.com/pennsieve/pennsieve-go-core/pkg/models/role"
 )
 
 type DatasetAuthorizer struct {
@@ -55,16 +56,16 @@ func (d *DatasetAuthorizer) GenerateClaims(ctx context.Context, claimsManager ma
 		}
 
 		return map[string]interface{}{
-			LabelUserClaim:         userClaim,
-			LabelOrganizationClaim: orgClaim,
-			LabelDatasetClaim:      datasetClaim,
-			LabelTeamClaims:        teamClaims,
+			coreAuthorizer.LabelUserClaim:         userClaim,
+			coreAuthorizer.LabelOrganizationClaim: orgClaim,
+			coreAuthorizer.LabelDatasetClaim:      datasetClaim,
+			coreAuthorizer.LabelTeamClaims:        teamClaims,
 		}, nil
 	}
 
 	return map[string]interface{}{
-		LabelUserClaim:         userClaim,
-		LabelOrganizationClaim: orgClaim,
-		LabelDatasetClaim:      datasetClaim,
+		coreAuthorizer.LabelUserClaim:         userClaim,
+		coreAuthorizer.LabelOrganizationClaim: orgClaim,
+		coreAuthorizer.LabelDatasetClaim:      datasetClaim,
 	}, nil
 }

--- a/lambda/authorizer/authorizers/dataset_authorizer_test.go
+++ b/lambda/authorizer/authorizers/dataset_authorizer_test.go
@@ -3,6 +3,7 @@ package authorizers_test
 import (
 	"context"
 	"fmt"
+	coreAuthorizer "github.com/pennsieve/pennsieve-go-core/pkg/authorizer"
 	"testing"
 
 	"github.com/pennsieve/pennsieve-go-api/authorizer/authorizers"
@@ -16,12 +17,15 @@ func TestDatasetAuthorizer(t *testing.T) {
 	claims, _ := authorizer.GenerateClaims(context.Background(), claimsManager, "")
 
 	assert.Equal(t, len(claims), 3)
-	assert.Equal(t, fmt.Sprintf("%s", claims[authorizers.LabelUserClaim]),
-		"User: 1 - N:user:someRandomUuid | isSuperAdmin: true")
-	assert.Equal(t, fmt.Sprintf("%s", claims[authorizers.LabelOrganizationClaim]),
-		"OrganizationId: 0 - NoPermission")
-	assert.Equal(t, fmt.Sprintf("%s", claims[authorizers.LabelDatasetClaim]),
-		" (0) - Manager")
+	assert.Equal(t,
+		mocks.MockUserClaim.String(),
+		fmt.Sprintf("%s", claims[coreAuthorizer.LabelUserClaim]))
+	assert.Equal(t,
+		mocks.MockOrgClaim.String(),
+		fmt.Sprintf("%s", claims[coreAuthorizer.LabelOrganizationClaim]))
+	assert.Equal(t,
+		mocks.MockDatasetClaim.String(),
+		fmt.Sprintf("%s", claims[coreAuthorizer.LabelDatasetClaim]))
 }
 
 func TestDatasetAuthorizerLegacy(t *testing.T) {
@@ -30,12 +34,23 @@ func TestDatasetAuthorizerLegacy(t *testing.T) {
 	claims, _ := authorizer.GenerateClaims(context.Background(), claimsManager, "LEGACY")
 
 	assert.Equal(t, len(claims), 4)
-	assert.Equal(t, fmt.Sprintf("%s", claims[authorizers.LabelUserClaim]),
-		"User: 1 - N:user:someRandomUuid | isSuperAdmin: true")
-	assert.Equal(t, fmt.Sprintf("%s", claims[authorizers.LabelOrganizationClaim]),
-		"OrganizationId: 0 - NoPermission")
-	assert.Equal(t, fmt.Sprintf("%s", claims[authorizers.LabelDatasetClaim]),
-		" (0) - Manager")
-	assert.Equal(t, fmt.Sprintf("%s", claims[authorizers.LabelTeamClaims]),
-		"[Name: someTeam1 (id: 1 nodeId:  permission: 0)]")
+	assert.Equal(t,
+		mocks.MockUserClaim.String(),
+		fmt.Sprintf("%s", claims[coreAuthorizer.LabelUserClaim]))
+	assert.Equal(t,
+		mocks.MockOrgClaim.String(),
+		fmt.Sprintf("%s", claims[coreAuthorizer.LabelOrganizationClaim]))
+	assert.Equal(t,
+		mocks.MockDatasetClaim.String(),
+		fmt.Sprintf("%s", claims[coreAuthorizer.LabelDatasetClaim]))
+
+	expectedTeamClaims := "["
+	separator := ""
+	for _, claim := range mocks.MockTeamClaims {
+		expectedTeamClaims += fmt.Sprintf("%s%s", separator, claim)
+	}
+	expectedTeamClaims += "]"
+	assert.Equal(t,
+		expectedTeamClaims,
+		fmt.Sprintf("%s", claims[coreAuthorizer.LabelTeamClaims]))
 }

--- a/lambda/authorizer/authorizers/manifest_authorizer.go
+++ b/lambda/authorizer/authorizers/manifest_authorizer.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	coreAuthorizer "github.com/pennsieve/pennsieve-go-core/pkg/authorizer"
 
 	"github.com/pennsieve/pennsieve-go-api/authorizer/manager"
-	"github.com/pennsieve/pennsieve-go-core/pkg/models/dataset/role"
+	"github.com/pennsieve/pennsieve-go-core/pkg/models/role"
 )
 
 // will be deprecated
@@ -61,16 +62,16 @@ func (m *ManifestAuthorizer) GenerateClaims(ctx context.Context, claimsManager m
 		}
 
 		return map[string]interface{}{
-			LabelUserClaim:         userClaim,
-			LabelOrganizationClaim: orgClaim,
-			LabelDatasetClaim:      datasetClaim,
-			LabelTeamClaims:        teamClaims,
+			coreAuthorizer.LabelUserClaim:         userClaim,
+			coreAuthorizer.LabelOrganizationClaim: orgClaim,
+			coreAuthorizer.LabelDatasetClaim:      datasetClaim,
+			coreAuthorizer.LabelTeamClaims:        teamClaims,
 		}, nil
 	}
 
 	return map[string]interface{}{
-		LabelUserClaim:         userClaim,
-		LabelOrganizationClaim: orgClaim,
-		LabelDatasetClaim:      datasetClaim,
+		coreAuthorizer.LabelUserClaim:         userClaim,
+		coreAuthorizer.LabelOrganizationClaim: orgClaim,
+		coreAuthorizer.LabelDatasetClaim:      datasetClaim,
 	}, nil
 }

--- a/lambda/authorizer/authorizers/manifest_authorizer_test.go
+++ b/lambda/authorizer/authorizers/manifest_authorizer_test.go
@@ -3,6 +3,7 @@ package authorizers_test
 import (
 	"context"
 	"fmt"
+	coreAuthorizer "github.com/pennsieve/pennsieve-go-core/pkg/authorizer"
 	"testing"
 
 	"github.com/pennsieve/pennsieve-go-api/authorizer/authorizers"
@@ -16,12 +17,15 @@ func TestManifestAuthorizer(t *testing.T) {
 	claims, _ := authorizer.GenerateClaims(context.Background(), claimsManager, "")
 
 	assert.Equal(t, len(claims), 3)
-	assert.Equal(t, fmt.Sprintf("%s", claims[authorizers.LabelUserClaim]),
-		"User: 1 - N:user:someRandomUuid | isSuperAdmin: true")
-	assert.Equal(t, fmt.Sprintf("%s", claims[authorizers.LabelOrganizationClaim]),
-		"OrganizationId: 0 - NoPermission")
-	assert.Equal(t, fmt.Sprintf("%s", claims[authorizers.LabelDatasetClaim]),
-		" (0) - Manager")
+	assert.Equal(t,
+		mocks.MockUserClaim.String(),
+		fmt.Sprintf("%s", claims[coreAuthorizer.LabelUserClaim]))
+	assert.Equal(t,
+		mocks.MockOrgClaim.String(),
+		fmt.Sprintf("%s", claims[coreAuthorizer.LabelOrganizationClaim]))
+	assert.Equal(t,
+		mocks.MockDatasetClaim.String(),
+		fmt.Sprintf("%s", claims[coreAuthorizer.LabelDatasetClaim]))
 }
 
 func TestManifestAuthorizerLegacy(t *testing.T) {
@@ -30,12 +34,22 @@ func TestManifestAuthorizerLegacy(t *testing.T) {
 	claims, _ := authorizer.GenerateClaims(context.Background(), claimsManager, "LEGACY")
 
 	assert.Equal(t, len(claims), 4)
-	assert.Equal(t, fmt.Sprintf("%s", claims[authorizers.LabelUserClaim]),
-		"User: 1 - N:user:someRandomUuid | isSuperAdmin: true")
-	assert.Equal(t, fmt.Sprintf("%s", claims[authorizers.LabelOrganizationClaim]),
-		"OrganizationId: 0 - NoPermission")
-	assert.Equal(t, fmt.Sprintf("%s", claims[authorizers.LabelDatasetClaim]),
-		" (0) - Manager")
-	assert.Equal(t, fmt.Sprintf("%s", claims[authorizers.LabelTeamClaims]),
-		"[Name: someTeam1 (id: 1 nodeId:  permission: 0)]")
+	assert.Equal(t,
+		mocks.MockUserClaim.String(),
+		fmt.Sprintf("%s", claims[coreAuthorizer.LabelUserClaim]))
+	assert.Equal(t,
+		mocks.MockOrgClaim.String(),
+		fmt.Sprintf("%s", claims[coreAuthorizer.LabelOrganizationClaim]))
+	assert.Equal(t,
+		mocks.MockDatasetClaim.String(),
+		fmt.Sprintf("%s", claims[coreAuthorizer.LabelDatasetClaim]))
+	expectedTeamClaims := "["
+	separator := ""
+	for _, claim := range mocks.MockTeamClaims {
+		expectedTeamClaims += fmt.Sprintf("%s%s", separator, claim)
+	}
+	expectedTeamClaims += "]"
+	assert.Equal(t,
+		expectedTeamClaims,
+		fmt.Sprintf("%s", claims[coreAuthorizer.LabelTeamClaims]))
 }

--- a/lambda/authorizer/authorizers/user_authorizer.go
+++ b/lambda/authorizer/authorizers/user_authorizer.go
@@ -3,6 +3,7 @@ package authorizers
 import (
 	"context"
 	"fmt"
+	coreAuthorizer "github.com/pennsieve/pennsieve-go-core/pkg/authorizer"
 
 	"github.com/pennsieve/pennsieve-go-api/authorizer/manager"
 )
@@ -41,13 +42,13 @@ func (u *UserAuthorizer) GenerateClaims(ctx context.Context, claimsManager manag
 		}
 
 		return map[string]interface{}{
-			LabelUserClaim:         userClaim,
-			LabelOrganizationClaim: orgClaim,
-			LabelTeamClaims:        teamClaims,
+			coreAuthorizer.LabelUserClaim:         userClaim,
+			coreAuthorizer.LabelOrganizationClaim: orgClaim,
+			coreAuthorizer.LabelTeamClaims:        teamClaims,
 		}, nil
 	}
 
 	return map[string]interface{}{
-		LabelUserClaim: userClaim,
+		coreAuthorizer.LabelUserClaim: userClaim,
 	}, nil
 }

--- a/lambda/authorizer/authorizers/user_authorizer_test.go
+++ b/lambda/authorizer/authorizers/user_authorizer_test.go
@@ -3,6 +3,7 @@ package authorizers_test
 import (
 	"context"
 	"fmt"
+	coreAuthorizer "github.com/pennsieve/pennsieve-go-core/pkg/authorizer"
 	"testing"
 
 	"github.com/pennsieve/pennsieve-go-api/authorizer/authorizers"
@@ -16,8 +17,9 @@ func TestUserAuthorizer(t *testing.T) {
 	claims, _ := authorizer.GenerateClaims(context.Background(), claimsManager, "")
 
 	assert.Equal(t, len(claims), 1)
-	assert.Equal(t, fmt.Sprintf("%s", claims[authorizers.LabelUserClaim]),
-		"User: 1 - N:user:someRandomUuid | isSuperAdmin: true")
+	assert.Equal(t,
+		mocks.MockUserClaim.String(),
+		fmt.Sprintf("%s", claims[coreAuthorizer.LabelUserClaim]))
 }
 
 func TestUserAuthorizerLegacy(t *testing.T) {
@@ -26,10 +28,19 @@ func TestUserAuthorizerLegacy(t *testing.T) {
 	claims, _ := authorizer.GenerateClaims(context.Background(), claimsManager, "LEGACY")
 
 	assert.Equal(t, len(claims), 3)
-	assert.Equal(t, fmt.Sprintf("%s", claims[authorizers.LabelUserClaim]),
-		"User: 1 - N:user:someRandomUuid | isSuperAdmin: true")
-	assert.Equal(t, fmt.Sprintf("%s", claims[authorizers.LabelOrganizationClaim]),
-		"OrganizationId: 0 - NoPermission")
-	assert.Equal(t, fmt.Sprintf("%s", claims[authorizers.LabelTeamClaims]),
-		"[Name: someTeam1 (id: 1 nodeId:  permission: 0)]")
+	assert.Equal(t,
+		mocks.MockUserClaim.String(),
+		fmt.Sprintf("%s", claims[coreAuthorizer.LabelUserClaim]))
+	assert.Equal(t,
+		mocks.MockOrgClaim.String(),
+		fmt.Sprintf("%s", claims[coreAuthorizer.LabelOrganizationClaim]))
+	expectedTeamClaims := "["
+	separator := ""
+	for _, claim := range mocks.MockTeamClaims {
+		expectedTeamClaims += fmt.Sprintf("%s%s", separator, claim)
+	}
+	expectedTeamClaims += "]"
+	assert.Equal(t,
+		expectedTeamClaims,
+		fmt.Sprintf("%s", claims[coreAuthorizer.LabelTeamClaims]))
 }

--- a/lambda/authorizer/authorizers/workspace_authorizer.go
+++ b/lambda/authorizer/authorizers/workspace_authorizer.go
@@ -3,6 +3,7 @@ package authorizers
 import (
 	"context"
 	"fmt"
+	coreAuthorizer "github.com/pennsieve/pennsieve-go-core/pkg/authorizer"
 
 	"github.com/pennsieve/pennsieve-go-api/authorizer/manager"
 )
@@ -42,8 +43,8 @@ func (w *WorkspaceAuthorizer) GenerateClaims(ctx context.Context, claimsManager 
 	userClaim := claimsManager.GetUserClaim(ctx, currentUser)
 
 	return map[string]interface{}{
-		LabelUserClaim:         userClaim,
-		LabelOrganizationClaim: orgClaim,
-		LabelTeamClaims:        teamClaims,
+		coreAuthorizer.LabelUserClaim:         userClaim,
+		coreAuthorizer.LabelOrganizationClaim: orgClaim,
+		coreAuthorizer.LabelTeamClaims:        teamClaims,
 	}, nil
 }

--- a/lambda/authorizer/authorizers/workspace_authorizer_test.go
+++ b/lambda/authorizer/authorizers/workspace_authorizer_test.go
@@ -3,6 +3,7 @@ package authorizers_test
 import (
 	"context"
 	"fmt"
+	coreAuthorizer "github.com/pennsieve/pennsieve-go-core/pkg/authorizer"
 	"testing"
 
 	"github.com/pennsieve/pennsieve-go-api/authorizer/authorizers"
@@ -16,10 +17,19 @@ func TestWorkspaceAuthorizer(t *testing.T) {
 	claims, _ := authorizer.GenerateClaims(context.Background(), claimsManager, "")
 
 	assert.Equal(t, len(claims), 3)
-	assert.Equal(t, fmt.Sprintf("%s", claims[authorizers.LabelUserClaim]),
-		"User: 1 - N:user:someRandomUuid | isSuperAdmin: true")
-	assert.Equal(t, fmt.Sprintf("%s", claims[authorizers.LabelOrganizationClaim]),
-		"OrganizationId: 0 - NoPermission")
-	assert.Equal(t, fmt.Sprintf("%s", claims[authorizers.LabelTeamClaims]),
-		"[Name: someTeam1 (id: 1 nodeId:  permission: 0)]")
+	assert.Equal(t,
+		mocks.MockUserClaim.String(),
+		fmt.Sprintf("%s", claims[coreAuthorizer.LabelUserClaim]))
+	assert.Equal(t,
+		mocks.MockOrgClaim.String(),
+		fmt.Sprintf("%s", claims[coreAuthorizer.LabelOrganizationClaim]))
+	expectedTeamClaims := "["
+	separator := ""
+	for _, claim := range mocks.MockTeamClaims {
+		expectedTeamClaims += fmt.Sprintf("%s%s", separator, claim)
+	}
+	expectedTeamClaims += "]"
+	assert.Equal(t,
+		expectedTeamClaims,
+		fmt.Sprintf("%s", claims[coreAuthorizer.LabelTeamClaims]))
 }

--- a/lambda/authorizer/go.mod
+++ b/lambda/authorizer/go.mod
@@ -1,13 +1,13 @@
 module github.com/pennsieve/pennsieve-go-api/authorizer
 
-go 1.18
+go 1.22
 
 require (
 	github.com/aws/aws-lambda-go v1.32.0
 	github.com/aws/aws-sdk-go-v2/config v1.18.14
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.18.4
 	github.com/lestrrat-go/jwx/v2 v2.0.11
-	github.com/pennsieve/pennsieve-go-core v1.7.6
+	github.com/pennsieve/pennsieve-go-core v1.13.0
 	github.com/sirupsen/logrus v1.9.0
 	github.com/stretchr/testify v1.8.4
 )
@@ -32,8 +32,10 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0 // indirect
 	github.com/goccy/go-json v0.10.2 // indirect
+	github.com/golang-jwt/jwt/v5 v5.2.1 // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
+	github.com/kr/text v0.2.0 // indirect
 	github.com/lestrrat-go/blackmagic v1.0.1 // indirect
 	github.com/lestrrat-go/httpcc v1.0.1 // indirect
 	github.com/lestrrat-go/httprc v1.0.4 // indirect
@@ -41,8 +43,9 @@ require (
 	github.com/lestrrat-go/option v1.0.1 // indirect
 	github.com/lib/pq v1.10.7 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/rogpeppe/go-internal v1.13.1 // indirect
 	github.com/segmentio/asm v1.2.0 // indirect
 	golang.org/x/crypto v0.17.0 // indirect
-	golang.org/x/sys v0.15.0 // indirect
+	golang.org/x/sys v0.21.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/lambda/authorizer/go.sum
+++ b/lambda/authorizer/go.sum
@@ -39,6 +39,7 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.18.4 h1:j0USUNbl9c/8tBJ8setEbwxc7wva
 github.com/aws/aws-sdk-go-v2/service/sts v1.18.4/go.mod h1:1mKZHLLpDMHTNSYPJ7qrcnCQdHCWsNQaT0xRvq2u80s=
 github.com/aws/smithy-go v1.13.5 h1:hgz0X/DX0dGqTYpGALqXJoRKRj5oQ7150i5FdTePzO8=
 github.com/aws/smithy-go v1.13.5/go.mod h1:Tg+OJXh4MB2R/uN61Ko2f6hTZwB/ZYGOtib8J3gBHzA=
+github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -47,6 +48,8 @@ github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0 h1:8UrgZ3GkP4i/CLijOJx79Yu+etly
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0/go.mod h1:v57UDF4pDQJcEfFUCRop3lJL149eHGSe9Jvczhzjo/0=
 github.com/goccy/go-json v0.10.2 h1:CrxCmQqYDkv1z7lO7Wbh2HN93uovUHgrECaO5ZrCXAU=
 github.com/goccy/go-json v0.10.2/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
+github.com/golang-jwt/jwt/v5 v5.2.1 h1:OuVbFODueb089Lh128TAcimifWaLhJwVflnrgM17wHk=
+github.com/golang-jwt/jwt/v5 v5.2.1/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
@@ -55,6 +58,10 @@ github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9Y
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
+github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
+github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=
+github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/lestrrat-go/blackmagic v1.0.1 h1:lS5Zts+5HIC/8og6cGHb0uCcNCa3OUt1ygh3Qz2Fe80=
 github.com/lestrrat-go/blackmagic v1.0.1/go.mod h1:UrEqBzIR2U6CnzVyUtfM6oZNMt/7O7Vohk2J0OGSAtU=
 github.com/lestrrat-go/httpcc v1.0.1 h1:ydWCStUeJLkpYyjLDHihupbn2tYmZ7m22BGkcvZZrIE=
@@ -70,10 +77,12 @@ github.com/lestrrat-go/option v1.0.1 h1:oAzP2fvZGQKWkvHa1/SAcFolBEca1oN+mQ7eooNB
 github.com/lestrrat-go/option v1.0.1/go.mod h1:5ZHFbivi4xwXxhxY9XHDe2FHo6/Z7WWmtT7T5nBBp3I=
 github.com/lib/pq v1.10.7 h1:p7ZhMD+KsSRozJr34udlUrhboJwWAgCg34+/ZZNvZZw=
 github.com/lib/pq v1.10.7/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
-github.com/pennsieve/pennsieve-go-core v1.7.6 h1:qy45Y0lZiEwwTWWnWue+WJrA72PB81fKmuhF7lHEbPk=
-github.com/pennsieve/pennsieve-go-core v1.7.6/go.mod h1:SAv7Ijk6RW4fo691bv2/XwIvgEJQ+DApL7smDI7Gjqo=
+github.com/pennsieve/pennsieve-go-core v1.13.0 h1:fn5X8h9AXzx19+/rdmXSakqdIy9mw04Rh5hTrtri/nQ=
+github.com/pennsieve/pennsieve-go-core v1.13.0/go.mod h1:MeMDPuGOXkY8q+opOES8r7ib3EAt5dveB+PMjgtLNKM=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=
+github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWNMNyH2VO9fmH0o=
 github.com/segmentio/asm v1.2.0 h1:9BQrFxC+YOHJlTlHGkTrFWf59nbL3XnCoFLTwDCI7ys=
 github.com/segmentio/asm v1.2.0/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=
 github.com/sirupsen/logrus v1.9.0 h1:trlNQbNUG3OdDrDil03MCb1H2o9nJ1x4/5LYw7byDE0=
@@ -112,8 +121,8 @@ golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.15.0 h1:h48lPFYpsTvQJZF4EKyI4aLHaev3CxivZmv7yZig9pc=
-golang.org/x/sys v0.15.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.21.0 h1:rF+pYz3DAGSQAxAu1CbC7catZg4ebC4UIeIhKxBZvws=
+golang.org/x/sys v0.21.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.5.0/go.mod h1:jMB1sMXY+tzblOD4FWmEbocvup2/aLOaQEp7JmGp78k=
@@ -128,8 +137,9 @@ golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
 golang.org/x/tools v0.6.0/go.mod h1:Xwgl3UAJ/d3gWutnCtw505GrjyAbvKui8lOU390QaIU=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/lambda/authorizer/mocks/mocks.go
+++ b/lambda/authorizer/mocks/mocks.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/pennsieve/pennsieve-go-api/authorizer/manager"
 	"github.com/pennsieve/pennsieve-go-core/pkg/models/dataset"
-	"github.com/pennsieve/pennsieve-go-core/pkg/models/dataset/role"
 	"github.com/pennsieve/pennsieve-go-core/pkg/models/organization"
 	pgdbModels "github.com/pennsieve/pennsieve-go-core/pkg/models/pgdb"
+	"github.com/pennsieve/pennsieve-go-core/pkg/models/role"
 	"github.com/pennsieve/pennsieve-go-core/pkg/models/teamUser"
 	"github.com/pennsieve/pennsieve-go-core/pkg/models/user"
 )
@@ -30,24 +30,32 @@ func (m *MockClaimManager) GetCurrentUser(context.Context) (*pgdbModels.User, er
 	}, nil
 }
 
-func (m *MockClaimManager) GetUserClaim(context.Context, *pgdbModels.User) user.Claim {
-	return user.Claim{
-		Id:           1,
-		NodeId:       "N:user:someRandomUuid",
-		IsSuperAdmin: true,
-	}
+var MockUserClaim = user.Claim{
+	Id:           1,
+	NodeId:       "N:user:someRandomUuid",
+	IsSuperAdmin: true,
 }
+
+func (m *MockClaimManager) GetUserClaim(context.Context, *pgdbModels.User) user.Claim {
+	return MockUserClaim
+}
+
+var MockDatasetClaim = dataset.Claim{Role: role.Manager}
 
 func (m *MockClaimManager) GetDatasetClaim(context.Context, *pgdbModels.User, string, int64) (*dataset.Claim, error) {
-	return &dataset.Claim{Role: role.Manager}, nil
+	return &MockDatasetClaim, nil
 }
+
+var MockOrgClaim = organization.Claim{}
 
 func (m *MockClaimManager) GetOrgClaim(context.Context, *pgdbModels.User, int64) (*organization.Claim, error) {
-	return &organization.Claim{}, nil
+	return &MockOrgClaim, nil
 }
 
+var MockTeamClaims = []teamUser.Claim{{IntId: 1, Name: "someTeam1"}}
+
 func (m *MockClaimManager) GetTeamClaims(context.Context, *pgdbModels.User) ([]teamUser.Claim, error) {
-	return []teamUser.Claim{{IntId: 1, Name: "someTeam1"}}, nil
+	return MockTeamClaims, nil
 }
 
 func (m *MockClaimManager) GetDatasetID(context.Context, string) (*string, error) {


### PR DESCRIPTION
This updates Pennsieve Go API - in particular, the Authorizer - to use Pennsieve Go Core v1.13.0. The primary change is to use the const labels for the claim types. Note that the Authorizer implementations here directly return `map[string]interface{}` and do not user the `Claims` struct defined in Pennsieve Go Core; the AWS Event Response `Context` expects this. 

Test refactored:
1. switch the *expected* and *actual* values in the assertions
2. use the `String()` method on the Claim types