### PR TITLE
Set Go version to 1.22.10

### DIFF
--- a/lambda/authorizer/go.mod
+++ b/lambda/authorizer/go.mod
@@ -1,6 +1,6 @@
 module github.com/pennsieve/pennsieve-go-api/authorizer
 
-go 1.22
+go 1.22.10
 
 require (
 	github.com/aws/aws-lambda-go v1.32.0


### PR DESCRIPTION
The previous build failed with:
```
go: downloading go1.22 (linux/amd64)
go: download go1.22 for linux/amd64: toolchain not available
```

A little research found this StackOverflow article: [`toolchain not available` error prevents me from using any go commands](https://stackoverflow.com/questions/78519711/toolchain-not-available-error-prevents-me-from-using-any-go-commands). The most up-voted answer suggests being more specific when specifying the Go version: 

> Fixed it by editing the go.mod file.
>
> changed go 1.22 to go 1.22.0

I am proposing to use the most recent version of the 1.22 branch, at this time it is 1.22.10.