### PR TITLE
Fix OpenAPI YAML file

### DIFF
--- a/terraform/upload_service.yml
+++ b/terraform/upload_service.yml
@@ -2980,7 +2980,6 @@ paths:
             type: string
           required: true
           description: The MicroCT package ID
-      parameters:
         - in: query
           name: dataset_id
           schema:


### PR DESCRIPTION
Fixes a typo in the OpenAPI YAML file that is causing the readme GitHub action to fail.