### PR TITLE
Add application deploy status endpoints

### DIFF
--- a/terraform/gateway.tf
+++ b/terraform/gateway.tf
@@ -1,7 +1,7 @@
 resource "aws_apigatewayv2_api" "upload-service-gateway" {
-  name          = "serverless_upload_service"
+  name          = "Pennsieve API Version 2"
   protocol_type = "HTTP"
-  description = "API Gateway for Upload-Service V2"
+  description = "API Gateway for Pennsieve API V2"
   cors_configuration {
     allow_origins = ["*"]
     allow_methods = ["*"]

--- a/terraform/upload_service.yml
+++ b/terraform/upload_service.yml
@@ -3855,9 +3855,9 @@ paths:
 
   /applications/{id}/deployments:
     get:
-      summary: Get the deployment history for a specific application
+      summary: Get the deployment history for an application
       description: |
-        Get the deployment history for a specific application
+        Get the deployment history for an application
       x-amazon-apigateway-integration:
         $ref: '#/components/x-amazon-apigateway-integrations/app-deploy-service'
       operationId: getDeployments
@@ -3872,6 +3872,12 @@ paths:
           schema:
             type: string
           description: The uuid of the application
+        - in: query
+          name: organization_id
+          required: true
+          schema:
+            type: string
+          description: the node id of the application's workspace
       responses:
         '200':
           description: The requested deployment history
@@ -3916,6 +3922,12 @@ paths:
           schema:
             type: string
           description: The uuid of the deployment
+        - in: query
+          name: organization_id
+          required: true
+          schema:
+            type: string
+          description: the node id of the application's workspace
       responses:
         '200':
           description: The requested deployment details

--- a/terraform/upload_service.yml
+++ b/terraform/upload_service.yml
@@ -1,4 +1,3 @@
-#file: noinspection MaybeTerraformTemplateInspection
 openapi: 3.0.1
 info:
   version: "3.0"

--- a/terraform/upload_service.yml
+++ b/terraform/upload_service.yml
@@ -367,7 +367,7 @@ components:
           type: array
           description: the packageIds
           items:
-            type: string  
+            type: string
     integrationResponse:
       type: object
       properties:
@@ -852,9 +852,11 @@ components:
     postApplicationsResponse:
       type: object
       properties:
-        postResponse:
+        deploymentId:
           type: string
-          description: the response from initiating creation of an application
+          description: a unique string identifying the app deployment
+        application:
+          $ref: '#/components/schemas/applicationsGetResponse'
     deleteApplicationsResponse:
       type: object
       properties:
@@ -898,11 +900,11 @@ components:
               type: string
               description: the account type of compute resource account
     postApplicationsDeployResponse:
-        type: object
-        properties:
-          postResponse:
-            type: string
-            description: the response from initiating deployment of an application
+      type: object
+      properties:
+        deploymentId:
+          type: string
+          description: a unique string identifying the initiated deployment
     workflowRequest:
       type: object
       properties:
@@ -1241,7 +1243,7 @@ components:
       allOf:
         - $ref: '#/components/schemas/drsObjectResponse'
       description: "Response containing the DRS object metadata and access methods."
-  
+
     multipleDrsObjectsRequest:
       type: object
       properties:
@@ -2891,9 +2893,9 @@ paths:
         '4XX':
           $ref: '#/components/responses/Unauthorized'
         '5XX':
-          $ref: '#/components/responses/Error'          
+          $ref: '#/components/responses/Error'
 
-  /integrations/{id}:          
+  /integrations/{id}:
     get:
       summary: Get integration by uuid
       description: |
@@ -2926,7 +2928,7 @@ paths:
         '5XX':
           $ref: '#/components/responses/Error'
 
-  /workflows/instances/{id}:          
+  /workflows/instances/{id}:
     get:
       summary: Get workflow instance by uuid
       description: |
@@ -2958,7 +2960,7 @@ paths:
         '5XX':
           $ref: '#/components/responses/Error'
 
-  /workflows/instances/{id}/logs:          
+  /workflows/instances/{id}/logs:
     get:
       summary: Get workflow instance processor logs
       description: |
@@ -2994,7 +2996,7 @@ paths:
         '4XX':
           $ref: '#/components/responses/Unauthorized'
         '5XX':
-          $ref: '#/components/responses/Error'         
+          $ref: '#/components/responses/Error'
 
   /workflows:
     post:
@@ -3025,7 +3027,7 @@ paths:
         '4XX':
           $ref: '#/components/responses/Unauthorized'
         '5XX':
-          $ref: '#/components/responses/Error'    
+          $ref: '#/components/responses/Error'
 
   /imaging/microct/{package_id}/session:
     post:
@@ -3974,7 +3976,7 @@ paths:
           description: "DrsObject not found"
         '401':
           description: "Unauthorized"
-      security: []
+      security: [ ]
 
     post:
       operationId: postUserById
@@ -3985,7 +3987,7 @@ paths:
         Returns object metadata, and a list of access methods that can be used to fetch object bytes.
         Method is a POST to accommodate a JWT GA4GH Passport sent in the formData in order to authorize access.
       tags:
-        - DRS Service      
+        - DRS Service
       parameters:
         - name: object_id
           in: path
@@ -4011,7 +4013,7 @@ paths:
         '401':
           description: "Unauthorized"
       security:
-        - PassportAuth: []
+        - PassportAuth: [ ]
 
   /ga4gh/drs/v1/objects:
     post:
@@ -4023,7 +4025,7 @@ paths:
         Returns an array of object metadata, and a list of access methods that can be used to fetch objects' bytes.
         Currently this is limited to use passports (one or more) or a single bearer token, so make sure your bulk request is for objects that all use the same passports/token.
       tags:
-        - DRS Service      
+        - DRS Service
       parameters:
         - name: expand
           in: query
@@ -4052,7 +4054,7 @@ paths:
         '401':
           description: "Unauthorized"
       security:
-        - PassportAuth: []
+        - PassportAuth: [ ]
 
 
   /ga4gh/drs/v1/objects/{object_id}/access/{access_id}:
@@ -4066,7 +4068,7 @@ paths:
         This method only needs to be called when using an AccessMethod that contains an access_id 
         (e.g., for servers that use signed URLs for fetching object bytes).
       tags:
-        - DRS Service      
+        - DRS Service
       parameters:
         - name: object_id
           in: path
@@ -4091,7 +4093,7 @@ paths:
           description: "Access URL not found"
         '401':
           description: "Unauthorized"
-      security: []
+      security: [ ]
 
     post:
       operationId: postUserbyAccessId
@@ -4136,7 +4138,7 @@ paths:
         '401':
           description: "Unauthorized"
       security:
-        - PassportAuth: []
+        - PassportAuth: [ ]
   /ga4gh/drs/v1/objects/access:
     post:
       operationId: postAllObjects
@@ -4150,7 +4152,7 @@ paths:
         Currently this is limited to use passports (one or more) or a single bearer token, 
         so make sure your bulk request is for objects that all use the same passports/token.
       tags:
-        - DRS Service        
+        - DRS Service
       requestBody:
         required: true
         content:
@@ -4169,7 +4171,7 @@ paths:
         '401':
           description: "Unauthorized"
       security:
-        - PassportAuth: []
+        - PassportAuth: [ ]
 
   /ga4gh/drs/v1/service-info:
     get:

--- a/terraform/upload_service.yml
+++ b/terraform/upload_service.yml
@@ -1,3 +1,4 @@
+#file: noinspection MaybeTerraformTemplateInspection
 openapi: 3.0.1
 info:
   version: "3.0"
@@ -215,6 +216,24 @@ components:
             properties:
               message:
                 type: string
+    BadRequest:
+      description: Bad Request
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              message:
+                type: string
+    NotFound:
+      description: Not Found
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              message:
+                type: string
     Error:
       description: Server Error
       content:
@@ -367,7 +386,7 @@ components:
           type: array
           description: the packageIds
           items:
-            type: string  
+            type: string
     integrationResponse:
       type: object
       properties:
@@ -896,6 +915,59 @@ components:
         deleteResponse:
           type: string
           description: the response from initiating deletion of an application
+    getDeploymentResponse:
+      type: object
+      properties:
+        deploymentId:
+          type: string
+          description: The unique identifier for the deployment.
+        applicationId:
+          type: string
+          description: The ID of the application associated with the deployment.
+        initiatedAt:
+          type: string
+          format: date-time
+          description: Timestamp when the deployment was initiated.
+        lastStatus:
+          type: string
+          description: The last known status of the deployment.
+        desiredStatus:
+          type: string
+          description: The desired status of the deployment.
+        taskArn:
+          type: string
+          description: ARN of the task associated with the deployment.
+        updatedAt:
+          type: string
+          format: date-time
+          nullable: true
+          description: Timestamp when the state change occurred.
+        createdAt:
+          type: string
+          format: date-time
+          nullable: true
+          description: The timestamp when the task was created (entered PENDING state).
+        startedAt:
+          type: string
+          format: date-time
+          nullable: true
+          description: The timestamp when the task started (entered RUNNING state).
+        stoppedAt:
+          type: string
+          format: date-time
+          nullable: true
+          description: The timestamp when the task stopped (entered STOPPED state).
+        stopCode:
+          type: string
+          nullable: true
+          description: An optional code indicating why the task was stopped.
+        stoppedReason:
+          type: string
+          nullable: true
+          description: A string indicating the reason why the task was stopped.
+        errored:
+          type: boolean
+          description: Indicates whether the task encountered an error.
     applicationDeployRequest:
       type: object
       properties:
@@ -1289,7 +1361,7 @@ components:
       allOf:
         - $ref: '#/components/schemas/drsObjectResponse'
       description: "Response containing the DRS object metadata and access methods."
-  
+
     multipleDrsObjectsRequest:
       type: object
       properties:
@@ -2939,9 +3011,9 @@ paths:
         '4XX':
           $ref: '#/components/responses/Unauthorized'
         '5XX':
-          $ref: '#/components/responses/Error'          
+          $ref: '#/components/responses/Error'
 
-  /integrations/{id}:          
+  /integrations/{id}:
     get:
       summary: Get integration by uuid
       description: |
@@ -2974,7 +3046,7 @@ paths:
         '5XX':
           $ref: '#/components/responses/Error'
 
-  /workflows/instances/{id}:          
+  /workflows/instances/{id}:
     get:
       summary: Get workflow instance by uuid
       description: |
@@ -3079,7 +3151,7 @@ paths:
         '5XX':
           $ref: '#/components/responses/Error'
 
-  /workflows/instances/{id}/logs:          
+  /workflows/instances/{id}/logs:
     get:
       summary: Get workflow instance processor logs
       description: |
@@ -3115,7 +3187,7 @@ paths:
         '4XX':
           $ref: '#/components/responses/Unauthorized'
         '5XX':
-          $ref: '#/components/responses/Error'         
+          $ref: '#/components/responses/Error'
 
   /workflows:
     post:
@@ -3146,7 +3218,7 @@ paths:
         '4XX':
           $ref: '#/components/responses/Unauthorized'
         '5XX':
-          $ref: '#/components/responses/Error'    
+          $ref: '#/components/responses/Error'
 
   /imaging/microct/{package_id}/session:
     post:
@@ -3782,6 +3854,85 @@ paths:
         '5XX':
           $ref: '#/components/responses/Error'
 
+  /applications/{id}/deployments:
+    get:
+      summary: Get the deployment history for a specific application
+      description: |
+        Get the deployment history for a specific application
+      x-amazon-apigateway-integration:
+        $ref: '#/components/x-amazon-apigateway-integrations/app-deploy-service'
+      operationId: getDeployments
+      security:
+        - token_workspace_auth: [ ]
+      tags:
+        - App Deploy Service
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+          description: The uuid of the application
+      responses:
+        '200':
+          description: The requested deployment history
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  deployments:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/getDeploymentResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '409':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/Error'
+
+  /applications/{id}/deployments/{deploymentId}:
+    get:
+      summary: Get the details for a specific application deployment
+      description: |
+        Get the details for a specific application deployment
+      x-amazon-apigateway-integration:
+        $ref: '#/components/x-amazon-apigateway-integrations/app-deploy-service'
+      operationId: getDeployment
+      security:
+        - token_workspace_auth: [ ]
+      tags:
+        - App Deploy Service
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+          description: The uuid of the application
+        - in: path
+          name: deploymentId
+          required: true
+          schema:
+            type: string
+          description: The uuid of the deployment
+      responses:
+        '200':
+          description: The requested deployment details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/getDeploymentResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/Error'
+
   /applications/deploy:
     post:
       summary: Deploys an application from a source to a destination
@@ -4131,7 +4282,7 @@ paths:
           description: "DrsObject not found"
         '401':
           description: "Unauthorized"
-      security: []
+      security: [ ]
 
     post:
       operationId: postUserById
@@ -4142,7 +4293,7 @@ paths:
         Returns object metadata, and a list of access methods that can be used to fetch object bytes.
         Method is a POST to accommodate a JWT GA4GH Passport sent in the formData in order to authorize access.
       tags:
-        - DRS Service      
+        - DRS Service
       parameters:
         - name: object_id
           in: path
@@ -4168,7 +4319,7 @@ paths:
         '401':
           description: "Unauthorized"
       security:
-        - PassportAuth: []
+        - PassportAuth: [ ]
 
   /ga4gh/drs/v1/objects:
     post:
@@ -4180,7 +4331,7 @@ paths:
         Returns an array of object metadata, and a list of access methods that can be used to fetch objects' bytes.
         Currently this is limited to use passports (one or more) or a single bearer token, so make sure your bulk request is for objects that all use the same passports/token.
       tags:
-        - DRS Service      
+        - DRS Service
       parameters:
         - name: expand
           in: query
@@ -4209,7 +4360,7 @@ paths:
         '401':
           description: "Unauthorized"
       security:
-        - PassportAuth: []
+        - PassportAuth: [ ]
 
 
   /ga4gh/drs/v1/objects/{object_id}/access/{access_id}:
@@ -4223,7 +4374,7 @@ paths:
         This method only needs to be called when using an AccessMethod that contains an access_id 
         (e.g., for servers that use signed URLs for fetching object bytes).
       tags:
-        - DRS Service      
+        - DRS Service
       parameters:
         - name: object_id
           in: path
@@ -4248,7 +4399,7 @@ paths:
           description: "Access URL not found"
         '401':
           description: "Unauthorized"
-      security: []
+      security: [ ]
 
     post:
       operationId: postUserbyAccessId
@@ -4293,7 +4444,7 @@ paths:
         '401':
           description: "Unauthorized"
       security:
-        - PassportAuth: []
+        - PassportAuth: [ ]
   /ga4gh/drs/v1/objects/access:
     post:
       operationId: postAllObjects
@@ -4307,7 +4458,7 @@ paths:
         Currently this is limited to use passports (one or more) or a single bearer token, 
         so make sure your bulk request is for objects that all use the same passports/token.
       tags:
-        - DRS Service        
+        - DRS Service
       requestBody:
         required: true
         content:
@@ -4326,7 +4477,7 @@ paths:
         '401':
           description: "Unauthorized"
       security:
-        - PassportAuth: []
+        - PassportAuth: [ ]
 
   /ga4gh/drs/v1/service-info:
     get:


### PR DESCRIPTION
Adds `GET /applications/{id}/deployments` and `GET /applications/{id}/deployments/deploymentId` to the OpenAPI spec. These endpoints are configured to use the workspace authorizer.

Also updates the documented return types of `POST /applications` and `POST /applications/deploy` to match current prod reality.

Updates `aws_apigatewayv2_api.name` and `.description` in Terraform to reflect that the AWS API Gateway defined here is not just the upload service.
