### PR TITLE
terraform: remove readme-service route definition

### DIFF
--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -155,18 +155,6 @@ data "terraform_remote_state" "rehydration_service" {
   }
 }
 
-# Import Readme Service
-data "terraform_remote_state" "readme_service" {
-  backend = "s3"
-
-  config = {
-    bucket  = "${var.aws_account}-terraform-state"
-    key     = "aws/${data.aws_region.current_region.name}/${var.vpc_name}/${var.environment_name}/readme-service/terraform.tfstate"
-    region  = "us-east-1"
-    profile = var.aws_account
-  }
-}
-
 # Import Account Service
 data "terraform_remote_state" "account_service" {
   backend = "s3"

--- a/terraform/gateway.tf
+++ b/terraform/gateway.tf
@@ -16,7 +16,6 @@ resource "aws_apigatewayv2_api" "upload-service-gateway" {
     imaging_service_lambda_arn = data.terraform_remote_state.imaging_service.outputs.imaging_service_api_lambda_arn,
     import_service_lambda_arn = data.terraform_remote_state.import_service.outputs.import_service_api_lambda_arn,
     rehydration_service_lambda_arn = data.terraform_remote_state.rehydration_service.outputs.rehydration_service_arn,
-    readme_service_lambda_arn = data.terraform_remote_state.readme_service.outputs.service_lambda_arn,
     account_service_lambda_arn = data.terraform_remote_state.account_service.outputs.service_lambda_arn,
     github_service_lambda_arn = data.terraform_remote_state.github_service.outputs.service_lambda_arn,
     user_pool_2_client_id = data.terraform_remote_state.authentication_service.outputs.user_pool_2_client_id,

--- a/terraform/upload_service.yml
+++ b/terraform/upload_service.yml
@@ -56,13 +56,6 @@ components:
       passthroughBehavior: when_no_match
       contentHandling: CONVERT_TO_TEXT
       payloadFormatVersion: 2.0
-    readme-service:
-      type: aws_proxy
-      uri: ${readme_service_lambda_arn}
-      httpMethod: POST
-      passthroughBehavior: when_no_match
-      contentHandling: CONVERT_TO_TEXT
-      payloadFormatVersion: 2.0
     account-service:
       type: aws_proxy
       uri: ${account_service_lambda_arn}
@@ -1549,37 +1542,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/rehydrationResponse'
-        '4XX':
-          $ref: '#/components/responses/Unauthorized'
-        '5XX':
-          $ref: '#/components/responses/Error'
-
-  /readme/docs/{slug}:
-    get:
-      summary: Get Pennsieve readme.io doc by slug
-      description: |
-        Gets Pennsieve readme.io doc by slug
-      x-amazon-apigateway-integration:
-        $ref: '#/components/x-amazon-apigateway-integrations/readme-service'
-      operationId: getReadmeDoc
-      security:
-        - token_auth: [ ]
-      tags:
-        - Readme Service
-      parameters:
-        - in: path
-          name: slug
-          required: true
-          schema:
-            type: string
-          description: The URL-safe slug of the readme.io doc. Slugs must be all lowercase, and replace spaces with hyphens.
-      responses:
-        '200':
-          description: The requested document
-          content:
-            application/json:
-              schema:
-                $ref: 'https://dash.readme.com/api/v1/schema#/components/schemas/docSchemaResponse'
         '4XX':
           $ref: '#/components/responses/Unauthorized'
         '5XX':


### PR DESCRIPTION
## Why

`readme-service` now owns its own API Gateway + OpenAPI spec — see [Pennsieve/readme-service#1](https://github.com/Pennsieve/readme-service/pull/1). Mirrors the `packages-service` pattern: one service, one spec, one gateway, mounted at `api2.pennsieve.{net,io}/readme` via `api_mapping_key`.

Continuing to define the same route here would leave two gateways racing for the same path. Cleanup.

## What's removed

- `/readme/docs/{slug}` route from `terraform/upload_service.yml`
- `readme-service` entry in `x-amazon-apigateway-integrations`
- `readme_service_lambda_arn` template variable from `terraform/gateway.tf`
- `data "terraform_remote_state" "readme_service"` block from `terraform/data.tf`

## What stays the same

- The route remains reachable at `https://api2.pennsieve.{net,io}/readme/docs/{slug}` (via the dedicated readme-service gateway after readme-service#1 deploys)
- Auth model identical: `token_auth` via the shared authorizer
- Plus a new `/readme/search` endpoint becomes available — also defined in the readme-service repo

## Deploy order — IMPORTANT

1. **First**: deploy `Pennsieve/readme-service#1` (new dedicated gateway live; both routes work)
2. **Verify**: `curl https://api2.pennsieve.net/readme/docs/uploading-data` resolves
3. **Then**: deploy this PR (legacy route definition removed)

Reversing the order causes a brief window where the route 404s. The `readme-service` Lambda's path regex tolerates both prefix-stripped and unstripped forms during the transition, so step 1 → 3 is safe.

## Test plan

- [ ] After deploy: `curl https://api2.pennsieve.net/readme/docs/uploading-data` (with valid JWT) still returns the guide
- [ ] After deploy: `curl https://api2.pennsieve.net/readme/search?query=upload` (with valid JWT) returns matching guides
- [ ] CloudWatch shows readme-service gateway taking traffic (not pennsieve-go-api gateway)