### PR TITLE
add GET /github/installations

### DIFF
--- a/terraform/upload_service.yml
+++ b/terraform/upload_service.yml
@@ -1053,7 +1053,29 @@ components:
         updated_at:
           type: string
           description: the date and time when the external repository was updated
-    
+
+    gitHubInstallations:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        avatar_url:
+          type: string
+        config_url:
+          type: string
+
+    getGitHubInstallationsResponse:
+      type: object
+      properties:
+        count:
+          type: integer
+        installations:
+          type: array
+          items:
+            $ref: "#/components/schemas/gitHubInstallations"
+
     ServiceInfoResponse:
       type: object
       properties:
@@ -1694,6 +1716,29 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/postRepositoryResponse'
+        '4XX':
+          $ref: '#/components/responses/Unauthorized'
+        '5XX':
+          $ref: '#/components/responses/Error'
+
+  /github/installations:
+    get:
+      summary: Get the Pennsieve GitHub App installations the user has access to
+      description: |
+        This operation will inquire with GitHub using the user's access token to obtain
+        the list of Pennsieve GitHub App installations the user has access to.
+      x-amazon-apigateway-integration:
+        $ref: '#/components/x-amazon-apigateway-integrations/github-service'
+      operationId: getGitHubAppInstallations
+      security:
+        - token_auth: [ ]
+      responses:
+        '200':
+          description: Successfully retrieved the list of Pennsieve GitHub App installations.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/getGitHubInstallationsResponse'
         '4XX':
           $ref: '#/components/responses/Unauthorized'
         '5XX':


### PR DESCRIPTION
Adds the API endpoint **GET** `/github/installations` which is serviced by the [GitHub Service](https://github.com/Pennsieve/github-service/pull/160). 

The endpoint requires standard user authentication, and returns a list of "brief" GitHub App Installation description suitable for providing hyperlink-outs to GitHub for viewing/configuring the app installation.