### PR TITLE
fix(authorizer): allow callback auth for dataset-less runs

### DIFF
--- a/lambda/authorizer/handler/callback.go
+++ b/lambda/authorizer/handler/callback.go
@@ -117,20 +117,28 @@ func handleCallbackAuth(ctx context.Context, event events.APIGatewayV2CustomAuth
 	}
 	claims[coreAuthorizer.LabelOrganizationClaim] = orgClaim
 
-	datasetClaim, err := postgresDB.GetDatasetClaim(ctx, currentUser, validateResp.DatasetNodeID, orgClaim.IntId)
-	if err != nil {
-		logger.WithError(err).Error("unable to get dataset claim")
-		return events.APIGatewayV2CustomAuthorizerSimpleResponse{
-			IsAuthorized: false,
-		}, nil
+	// Some runs are dataset-less by design — e.g. an environment-build workflow
+	// (builder → persistent-layer, no data-source node) takes no input dataset, so
+	// the validator returns an empty datasetNodeId. Only resolve + require a dataset
+	// claim when the run actually has a dataset; otherwise authorize with the user +
+	// organization claims alone (the run-scoped callback token already binds the
+	// request to this run and its organization).
+	if validateResp.DatasetNodeID != "" {
+		datasetClaim, err := postgresDB.GetDatasetClaim(ctx, currentUser, validateResp.DatasetNodeID, orgClaim.IntId)
+		if err != nil {
+			logger.WithError(err).Error("unable to get dataset claim")
+			return events.APIGatewayV2CustomAuthorizerSimpleResponse{
+				IsAuthorized: false,
+			}, nil
+		}
+		if datasetClaim.Role == role.None {
+			logger.Warn("user has no access to dataset")
+			return events.APIGatewayV2CustomAuthorizerSimpleResponse{
+				IsAuthorized: false,
+			}, nil
+		}
+		claims[coreAuthorizer.LabelDatasetClaim] = datasetClaim
 	}
-	if datasetClaim.Role == role.None {
-		logger.Warn("user has no access to dataset")
-		return events.APIGatewayV2CustomAuthorizerSimpleResponse{
-			IsAuthorized: false,
-		}, nil
-	}
-	claims[coreAuthorizer.LabelDatasetClaim] = datasetClaim
 
 	logger.Info("callback token authorization successful")
 	return events.APIGatewayV2CustomAuthorizerSimpleResponse{


### PR DESCRIPTION
## Bug
Creating an environment (the new "New Environment" flow) failed at trigger with:
```
error running trigger: execute request failed with status 500:
  Failed to fetch execution run: status 403, body: {"message":"Forbidden"}
```

## Root cause
The callback authorizer (`callback.go`) always resolves a **dataset claim** from the validator's `datasetNodeId` and denies if there's no dataset access. An **environment-build** run is **dataset-less by design** (its workflow is `builder → persistent-layer`, no data-source node), so the validator returns an empty `datasetNodeId`. `GetDatasetClaim("")` then fails / returns `role.None` → `IsAuthorized: false` → the generic 403. Every callback-authed orchestration call on the run (the gateway fetching it, status updates, layer-metadata callback) hit this, so the trigger failed. Notebook/normal runs have a dataset, so they were unaffected.

## Fix
Only resolve + require a dataset claim when `datasetNodeId` is non-empty; otherwise authorize with the user + organization claims alone. The run-scoped callback token already binds the request to the run and its org, and dataset-less orchestration calls don't need a dataset claim. No change for runs that have a dataset.

Unblocks dataset-less runs generally (environment builds being the first), which the public "Pennsieve - Build … Environment" workflows rely on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)