### PR TITLE
Add API Gateway routes for notification-service subscriptions

### DIFF
--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -202,3 +202,15 @@ data "terraform_remote_state" "workflow_service" {
     profile = var.aws_account
   }
 }
+
+# Notification Service
+data "terraform_remote_state" "notification_service" {
+  backend = "s3"
+
+  config = {
+    bucket  = "${var.aws_account}-terraform-state"
+    key     = "aws/${data.aws_region.current_region.name}/${var.vpc_name}/${var.environment_name}/notification-service/terraform.tfstate"
+    region  = "us-east-1"
+    profile = var.aws_account
+  }
+}

--- a/terraform/gateway.tf
+++ b/terraform/gateway.tf
@@ -18,6 +18,7 @@ resource "aws_apigatewayv2_api" "upload-service-gateway" {
     rehydration_service_lambda_arn = data.terraform_remote_state.rehydration_service.outputs.rehydration_service_arn,
     account_service_lambda_arn = data.terraform_remote_state.account_service.outputs.service_lambda_arn,
     github_service_lambda_arn = data.terraform_remote_state.github_service.outputs.service_lambda_arn,
+    notification_service_lambda_arn = data.terraform_remote_state.notification_service.outputs.service_lambda_arn,
     user_pool_2_client_id = data.terraform_remote_state.authentication_service.outputs.user_pool_2_client_id,
     user_pool_endpoint = "https://${var.user_pool_endpoint}"
     token_pool_client_id = data.terraform_remote_state.authentication_service.outputs.token_pool_client_id,

--- a/terraform/upload_service.yml
+++ b/terraform/upload_service.yml
@@ -70,6 +70,13 @@ components:
       passthroughBehavior: when_no_match
       contentHandling: CONVERT_TO_TEXT
       payloadFormatVersion: 2.0
+    notification-service:
+      type: aws_proxy
+      uri: ${notification_service_lambda_arn}
+      httpMethod: POST
+      passthroughBehavior: when_no_match
+      contentHandling: CONVERT_TO_TEXT
+      payloadFormatVersion: 2.0
   securitySchemes:
     BearerAuth:
       type: http
@@ -1228,6 +1235,84 @@ components:
           items:
             $ref: "#/components/schemas/gitHubInstallations"
 
+    notificationTopic:
+      type: object
+      properties:
+        id:
+          type: integer
+          description: the topic id
+        name:
+          type: string
+          description: the topic name
+        description:
+          type: string
+          description: a description of the topic
+
+    topicsResponse:
+      type: object
+      properties:
+        topics:
+          type: array
+          items:
+            $ref: "#/components/schemas/notificationTopic"
+
+    subscription:
+      type: object
+      properties:
+        topic_id:
+          type: integer
+          description: the id of the subscribed topic
+        topic_name:
+          type: string
+          description: the name of the subscribed topic
+        subscribed_at:
+          type: string
+          description: the date and time when the user subscribed to the topic
+
+    subscriptionsResponse:
+      type: object
+      properties:
+        subscriptions:
+          type: array
+          items:
+            $ref: "#/components/schemas/subscription"
+
+    notification:
+      type: object
+      properties:
+        id:
+          type: integer
+          description: the notification id
+        topic_id:
+          type: integer
+          description: the id of the topic the notification was published to
+        message:
+          type: string
+          description: the notification content
+        created_at:
+          type: string
+          description: the date and time when the notification was created
+
+    notificationsResponse:
+      type: object
+      properties:
+        page:
+          type: integer
+          description: the page number returned (1-based)
+        size:
+          type: integer
+          description: the page size (max items per page)
+        count:
+          type: integer
+          description: the number of notifications in this page
+        total:
+          type: integer
+          description: the total number of notifications across all pages
+        notifications:
+          type: array
+          items:
+            $ref: "#/components/schemas/notification"
+
     ServiceInfoResponse:
       type: object
       properties:
@@ -2084,6 +2169,165 @@ paths:
       responses:
         '200':
           description: The updated publication.
+        '4XX':
+          $ref: '#/components/responses/Unauthorized'
+        '5XX':
+          $ref: '#/components/responses/Error'
+
+  /notification/topics:
+    get:
+      summary: Get available notification topics
+      description: |
+        Returns the list of notification topics that a user may subscribe to.
+      x-amazon-apigateway-integration:
+        $ref: '#/components/x-amazon-apigateway-integrations/notification-service'
+      operationId: getNotificationTopics
+      security:
+        - token_auth: [ ]
+      tags:
+        - Notification Service
+      responses:
+        '200':
+          description: List of available notification topics.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/topicsResponse'
+        '4XX':
+          $ref: '#/components/responses/Unauthorized'
+        '5XX':
+          $ref: '#/components/responses/Error'
+
+  /notification/subscriptions:
+    get:
+      summary: Get the authenticated user's notification subscriptions
+      description: |
+        Returns the list of notification topics the authenticated user is currently subscribed to.
+      x-amazon-apigateway-integration:
+        $ref: '#/components/x-amazon-apigateway-integrations/notification-service'
+      operationId: getUserSubscriptions
+      security:
+        - token_auth: [ ]
+      tags:
+        - Notification Service
+      responses:
+        '200':
+          description: List of the user's notification subscriptions.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/subscriptionsResponse'
+        '4XX':
+          $ref: '#/components/responses/Unauthorized'
+        '5XX':
+          $ref: '#/components/responses/Error'
+
+  /notification/subscriptions/{topicId}:
+    post:
+      summary: Subscribe to a notification topic
+      description: |
+        Subscribes the authenticated user to the given notification topic.
+      x-amazon-apigateway-integration:
+        $ref: '#/components/x-amazon-apigateway-integrations/notification-service'
+      operationId: subscribeToTopic
+      security:
+        - token_auth: [ ]
+      tags:
+        - Notification Service
+      parameters:
+        - in: path
+          name: topicId
+          schema:
+            type: integer
+          required: true
+          description: the id of the topic to subscribe to
+      responses:
+        '200':
+          description: Successfully subscribed to the topic.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/subscription'
+        '4XX':
+          $ref: '#/components/responses/Unauthorized'
+        '5XX':
+          $ref: '#/components/responses/Error'
+    delete:
+      summary: Unsubscribe from a notification topic
+      description: |
+        Unsubscribes the authenticated user from the given notification topic.
+      x-amazon-apigateway-integration:
+        $ref: '#/components/x-amazon-apigateway-integrations/notification-service'
+      operationId: unsubscribeFromTopic
+      security:
+        - token_auth: [ ]
+      tags:
+        - Notification Service
+      parameters:
+        - in: path
+          name: topicId
+          schema:
+            type: integer
+          required: true
+          description: the id of the topic to unsubscribe from
+      responses:
+        '200':
+          description: Successfully unsubscribed from the topic.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+        '4XX':
+          $ref: '#/components/responses/Unauthorized'
+        '5XX':
+          $ref: '#/components/responses/Error'
+
+  /notification/{topicId}/notifications:
+    get:
+      summary: Retrieve notifications from a topic
+      description: |
+        Returns the notifications published to the given topic. This endpoint is paginated.
+      x-amazon-apigateway-integration:
+        $ref: '#/components/x-amazon-apigateway-integrations/notification-service'
+      operationId: getTopicNotifications
+      security:
+        - token_auth: [ ]
+      tags:
+        - Notification Service
+      parameters:
+        - in: path
+          name: topicId
+          schema:
+            type: integer
+          required: true
+          description: the id of the topic to retrieve notifications from
+        - in: query
+          name: page
+          schema:
+            type: integer
+            minimum: 1
+            default: 1
+          required: false
+          description: the page number to return
+        - in: query
+          name: size
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 25
+          required: false
+          description: the number of items to return on each page
+      responses:
+        '200':
+          description: List of notifications for the topic.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/notificationsResponse'
         '4XX':
           $ref: '#/components/responses/Unauthorized'
         '5XX':


### PR DESCRIPTION
## Summary
- Adds a `terraform_remote_state` data source for `notification_service`, mirroring the existing `github_service`/`drs_service` pattern (`terraform/data.tf`).
- Wires `notification_service_lambda_arn` into the API Gateway OpenAPI templatefile vars (`terraform/gateway.tf`).
- Adds the `notification-service` AWS_PROXY integration and the following routes to `terraform/upload_service.yml`, all gated on `token_auth`:
  - `GET /notification/topics` — list available topics
  - `GET /notification/subscriptions` — list the authenticated user's subscriptions
  - `POST /notification/subscriptions/{topicId}` — subscribe to a topic
  - `DELETE /notification/subscriptions/{topicId}` — unsubscribe from a topic (keyed by `topicId`, same id used to subscribe)
  - `GET /notification/{topicId}/notifications` — paginated (`page`/`size`) list of notifications for a topic
  - `POST /notifications` – Publish Notification (wait to implement this)
    - we may simply rely on SNS/SQS to drive the notification
    - if we get to user-to-user "messaging" we may revisit this
  - `PUT /messages/{messageId}/reply` – Reply to a notification or message (wait to implement this)
    - if we get to user-to-user "messaging" we may revisit this
- Adds corresponding schemas (`notificationTopic`, `topicsResponse`, `subscription`, `subscriptionsResponse`, `notification`, `notificationsResponse`).

## Notes for reviewers
- This only wires up the API Gateway layer. A `notification-service` Lambda with a `service_lambda_arn` terraform output still needs to exist/deploy before the remote state lookup will resolve.
- `topicId` is used consistently as the identifier across subscribe/unsubscribe/notifications routes (a single subscription per user/topic, so no separate `subscriptionId` was introduced).

## Test plan
- [ ] `terraform validate` / `terraform plan` once `notification-service` state exists
- [ ] Confirm OpenAPI template renders correctly via `terraform plan` diff on `aws_apigatewayv2_api.upload-service-gateway`