### PR TITLE
Remove unreferenced API Gateway integration

### DIFF
--- a/terraform/gateway.tf
+++ b/terraform/gateway.tf
@@ -53,13 +53,6 @@ resource "aws_apigatewayv2_stage" "upload-service-gateway-stage" {
   }
 }
 
-resource "aws_apigatewayv2_integration" "int" {
-  api_id           = aws_apigatewayv2_api.upload-service-gateway.id
-  integration_type = "AWS_PROXY"
-  connection_type = "INTERNET"
-  integration_method = "POST"
-  integration_uri = data.terraform_remote_state.upload-service.outputs.service_lambda_invoke_arn
-}
 
 resource "aws_cloudwatch_log_group" "upload-service-log-group" {
   name =  "${var.environment_name}/${var.service_name}/serverless_api_gateway"


### PR DESCRIPTION
Removes the `resource "aws_apigatewayv2_integration" "int"` block from Terraform.

All the active API integrations are created and managed by the OpenAPI spec. This standalone integration is probably left over from an earlier version or the initial experimentation and no route points to it. It is not doing any harm, but it constantly causes churn in our Terraform plans since AWS automatically prunes this unused integration and then its presence in our Terraform causes it to be re-created.

Non-prod Terraform plan:
```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  - destroy
-/+ destroy and then create replacement

Terraform will perform the following actions:

  # module.uploads_module.aws_apigatewayv2_integration.int will be destroyed
  # (because aws_apigatewayv2_integration.int is not in configuration)
  - resource "aws_apigatewayv2_integration" "int" {
      - api_id                 = "14i0ufp7jh" -> null
      - connection_type        = "INTERNET" -> null
      - id                     = "qp6edcf" -> null
      - integration_method     = "POST" -> null
      - integration_type       = "AWS_PROXY" -> null
      - integration_uri        = "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:941165240011:function:dev-upload-service-v2-service-lambda-use1/invocations" -> null
      - payload_format_version = "1.0" -> null
      - request_parameters     = {} -> null
      - request_templates      = {} -> null
      - timeout_milliseconds   = 30000 -> null
    }

  # module.uploads_module.aws_lambda_permission.allow_same_account_invoke_direct_authorizer must be replaced
-/+ resource "aws_lambda_permission" "allow_same_account_invoke_direct_authorizer" {
      ~ id                  = "AllowSameAccountLambdasInvoke" -> (known after apply)
      ~ principal           = "arn:aws:iam::941165240011:root" -> "941165240011" # forces replacement
      + statement_id_prefix = (known after apply)
        # (3 unchanged attributes hidden)
    }

Plan: 1 to add, 0 to change, 2 to destroy.
```

Proof that no routes in the referenced API (14i0ufp7jh) actually use the integration being deleted (qp6edcf):
```
johnfr@Johns-MacBook-Pro-48 pennsieve-go-api % aws apigatewayv2 get-routes \
  --api-id 14i0ufp7jh \
  --region us-east-1 \
  --query 'Items[].{Route:RouteKey,Target:Target}' \
  --output table
------------------------------------------------------------------------
|                               GetRoutes                              |
+---------------------------------------------+------------------------+
|                    Route                    |        Target          |
+---------------------------------------------+------------------------+
|  GET /github/installations                  |  integrations/m4wjih9  |
|  GET /manifest/files                        |  integrations/sebl8w8  |
|  GET /manifest/archive                      |  integrations/sebl8w8  |
|  DELETE /accounts/github/user               |  integrations/m4wjih9  |
|  POST /discover/rehydrate                   |  integrations/slp8hy8  |
|  GET /repositories                          |  integrations/m4wjih9  |
|  POST /manifest/archive                     |  integrations/sebl8w8  |
|  GET /manifest/status                       |  integrations/sebl8w8  |
|  POST /repository/{owner}/{repo}/publish    |  integrations/m4wjih9  |
|  DELETE /manifest/archive                   |  integrations/sebl8w8  |
|  PUT /repositories/publications/{id}/status |  integrations/m4wjih9  |
|  POST /imaging/microct/{package_id}/session |  integrations/a5jclfp  |
|  GET /accounts/github/user                  |  integrations/m4wjih9  |
|  POST /repositories                         |  integrations/m4wjih9  |
|  GET /repository/{owner}/{repo}             |  integrations/m4wjih9  |
|  POST /accounts/github/register             |  integrations/m4wjih9  |
|  GET /manifest                              |  integrations/sebl8w8  |
|  POST /webhooks/github                      |  integrations/m4wjih9  |
|  POST /manifest                             |  integrations/sebl8w8  |
+---------------------------------------------+------------------------+
```